### PR TITLE
Support Windows

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6.0-pre.alpha
-ArrayViews
 DataStructures
 Libz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+environment:
+  matrix:
+#  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $env:JULIA_URL,
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.clone(pwd(), \"JLD2\"); Pkg.build(\"JLD2\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"JLD2\", coverage=true)"
+
+on_success:
+  - C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"JLD2\")); Pkg.add(\"Coverage\"); Pkg.checkout(\"Coverage\"); using Coverage; Codecov.submit(process_folder())"

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -1,5 +1,6 @@
 using BenchmarkTools, JLD2
 
+const BACKEND = IOStream
 const TEMPFILE = begin
     tmp, io = mktemp()
     close(io)
@@ -7,13 +8,13 @@ const TEMPFILE = begin
 end
 
 function jld_benchmark_write(x)
-    f = jldopen(TEMPFILE, "w")
+    f = jldopen(TEMPFILE, true, true, true, BACKEND)
     write(f, "x", x)
     close(f)
 end
 
 function jld_benchmark_read()
-    f = jldopen(TEMPFILE)
+    f = jldopen(TEMPFILE, false, false, false, BACKEND)
     read(f, "x")
     close(f)
 end

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -1,6 +1,7 @@
 using BenchmarkTools, JLD2
 
-const BACKEND = IOStream
+const BACKEND = JLD2.MmapIO
+# const BACKEND = IOStream
 const TEMPFILE = begin
     tmp, io = mktemp()
     close(io)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -44,7 +44,8 @@ function write_attribute(io::IO, f::JLDFile, attr::WrittenAttribute, wsession::J
     write(io, UInt8(0))
     write(io, attr.datatype)
     write(io, attr.dataspace)
-    write_data(io, f, attr.data, objodr(attr.data), wsession)
+    odr = objodr(attr.data)
+    write_data(io, f, attr.data, odr, datamode(odr), wsession)
 end
 
 function read_attribute(io::IO, f::JLDFile)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -44,7 +44,7 @@ function write_attribute(io::IO, f::JLDFile, attr::WrittenAttribute, wsession::J
     write(io, UInt8(0))
     write(io, attr.datatype)
     write(io, attr.dataspace)
-    write_data(f, attr.data, objodr(attr.data), wsession)
+    write_data(io, f, attr.data, objodr(attr.data), wsession)
 end
 
 function read_attribute(io::IO, f::JLDFile)

--- a/src/bufferedio.jl
+++ b/src/bufferedio.jl
@@ -1,0 +1,170 @@
+#
+# BufferedIO
+#
+
+const Plain = Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128,Float16,Float32,
+                    Float64}
+const PlainType = Union{Type{Int16},Type{Int32},Type{Int64},Type{Int128},Type{UInt16},
+                        Type{UInt32},Type{UInt64},Type{UInt128},Type{Float16},
+                        Type{Float32},Type{Float64}}
+const DEFAULT_BUFFER_SIZE = 1024
+
+struct BufferedWriter <: IO
+    f::IOStream
+    buffer::Vector{UInt8}
+    file_position::Int64
+    position::Base.RefValue{Int}
+end
+
+function BufferedWriter(io::IOStream, buffer_size::Int)
+    pos = position(io)
+    skip(io, buffer_size)
+    BufferedWriter(io, Vector{UInt8}(buffer_size), pos, Ref{Int}(0))
+end
+Base.show(io::IO, ::BufferedWriter) = print(io, "BufferedWriter")
+
+function finish!(io::BufferedWriter)
+    f = io.f
+    buffer = io.buffer
+    io.position[] == length(buffer) ||
+        error("buffer not written to end; position is $(io.position[]) but length is $(length(buffer))")
+    seek(f, io.file_position)
+    write(f, buffer)
+    io.position[] = 0
+    nothing
+end
+
+@inline function _write(io::BufferedWriter, x)
+    position = io.position[]
+    buffer = io.buffer
+    n = sizeof(x)
+    n + position <= length(buffer) || throw(EOFError())
+    io.position[] = position + n
+    unsafe_store!(Ptr{typeof(x)}(pointer(buffer, position+1)), x)
+    # Base.show_backtrace(STDOUT, backtrace())
+    # gc()
+    return n
+end
+@inline Base.write(io::BufferedWriter, x::UInt8) = _write(io, x)
+@inline Base.write(io::BufferedWriter, x::Int8) = _write(io, x)
+@inline Base.write(io::BufferedWriter, x::Plain)  = _write(io, x)
+
+function Base.unsafe_write(io::BufferedWriter, x::Ptr{UInt8}, n::UInt64)
+    buffer = io.buffer
+    position = io.position[]
+    n + position <= length(buffer) || throw(EOFError())
+    unsafe_copy!(pointer(buffer, position+1), x, n)
+    io.position[] = position + n
+    # Base.show_backtrace(STDOUT, backtrace())
+    # gc()
+    return n
+end
+
+Base.position(io::BufferedWriter) = io.file_position + io.position[]
+
+struct BufferedReader <: IO
+    f::IOStream
+    buffer::Vector{UInt8}
+    file_position::Int64
+    position::Base.RefValue{Int}
+end
+
+BufferedReader(io::IOStream) =
+    BufferedReader(io, Vector{UInt8}(0), position(io), Ref{Int}(0))
+Base.show(io::IO, ::BufferedReader) = print(io, "BufferedReader")
+
+function readmore!(io::BufferedReader, n::Int)
+    f = io.f
+    amount = max(nb_available(f), n)
+    buffer = io.buffer
+    oldlen = length(buffer)
+    resize!(buffer, oldlen + amount)
+    unsafe_read(f, pointer(buffer, oldlen+1), amount)
+end
+
+@inline function _read(io::BufferedReader, T::DataType)
+    position = io.position[]
+    buffer = io.buffer
+    if length(buffer) - position < sizeof(T)
+        readmore!(io, sizeof(T))
+    end
+    io.position[] = position + sizeof(T)
+    unsafe_load(Ptr{T}(pointer(buffer, position+1)))
+end
+@inline Base.read(io::BufferedReader, T::Type{UInt8}) = _read(io, T)
+@inline Base.read(io::BufferedReader, T::Type{Int8}) = _read(io, T)
+@inline Base.read(io::BufferedReader, T::PlainType) = _read(io, T)
+
+function Base.read{T}(io::BufferedReader, ::Type{T}, n::Int)
+    position = io.position[]
+    buffer = io.buffer
+    n = sizeof(T) * n
+    if length(buffer) - position < n
+        readmore!(io, sizeof(T))
+    end
+    io.position[] = position + n
+    arr = Vector{T}(n)
+    unsafe_copy!(pointer(arr), Ptr{T}(pointer(buffer, position+1)), n)
+    arr
+end
+Base.read{T}(io::BufferedReader, ::Type{T}, n::Integer) =
+    read(io, T, Int(n))
+
+# Read a null-terminated string
+function read_bytestring(io::BufferedReader)
+    position = io.position[]
+    buffer = io.buffer
+    endpos = -1
+    i = startpos
+    while true
+        buflen = length(buffer)
+        while i < buflen
+            if buffer[i+1] == 0x00
+                endpos = i
+                break
+            end
+            i += 1
+        end
+        endpos != -1 && break
+        readmore!(io, 1)
+    end
+    io.position[] = i
+    String(buffer[position+1:endpos+1])
+end
+
+Base.position(io::BufferedReader) = io.file_position + io.position[]
+
+function adjust_position!(io::BufferedReader, position::Integer)
+    if position < 0
+        throw(ArgumentError("cannot seek before start of buffer"))
+    elseif position > length(io.buffer)
+        readmore!(io, position - length(io.buffer))
+    end
+    io.position[] = position
+end
+
+Base.seek(io::BufferedReader, offset::Integer) =
+    adjust_position!(io, offset - io.file_position)
+
+Base.skip(io::BufferedReader, offset::Integer) =
+    adjust_position!(io, io.position[] + offset)
+
+finish!(io::BufferedReader) =
+    seek(io.f, io.file_position + io.position[])
+
+# We sometimes need to compute checksums. We do this by first calling begin_checksum when
+# starting to handle whatever needs checksumming, and calling end_checksum afterwards. Note
+# that we never compute nested checksums, but we may compute multiple checksums
+# simultaneously.
+
+function begin_checksum_read(io::IOStream)
+    BufferedReader(io)
+end
+function begin_checksum_write(io::IOStream, sz::Integer)
+    BufferedWriter(io, sz)
+end
+function end_checksum(io::Union{BufferedReader,BufferedWriter})
+    ret = Lookup3.hash(io.buffer, 1, io.position[])
+    finish!(io)
+    ret
+end

--- a/src/dataio.jl
+++ b/src/dataio.jl
@@ -1,0 +1,280 @@
+"""
+    read_scalar(f::JLDFile, rr, header_offset::RelOffset)
+
+Read raw data representing a scalar with read representation `rr` from the current position
+of JLDFile `f`. `header_offset` is the RelOffset of the object header, used to resolve
+cycles.
+"""
+function read_scalar end
+
+"""
+    read_array!(v::Array, f::JLDFile, rr)
+
+Fill the array `v` with the contents of JLDFile `f` at the current position, assuming a
+ReadRepresentation `rr`.
+"""
+function read_array! end
+
+
+"""
+    read_compressed_array!(v::Array, f::JLDFile, rr, data_length::Int)
+
+Fill the array `v` with the compressed contents of JLDFile `f` at the current position,
+assuming a ReadRepresentation `rr` and that the compressed data has length `data_length`.
+"""
+function read_compressed_array! end
+
+#
+# MmapIO
+#
+
+# Cutoff for using ordinary IO instead of copying into mmapped region
+const MMAP_CUTOFF = 1048576
+
+@inline function read_scalar(f::JLDFile{MmapIO}, rr, header_offset::RelOffset)
+    io = f.io
+    inptr = io.curptr
+    obj = jlconvert(rr, f, inptr, header_offset)
+    io.curptr = inptr + sizeof(rr)
+    obj
+end
+
+@inline function read_array!{T}(v::Array{T}, f::JLDFile{MmapIO},
+                                rr::ReadRepresentation{T,T})
+    io = f.io
+    inptr = io.curptr
+    n = length(v)
+    nb = sizeof(T)*n
+    if nb > MMAP_CUTOFF
+        # It turns out that regular IO is faster here (at least on OS X)
+        mmapio = f.io
+        regulario = mmapio.f
+        seek(regulario, inptr - io.startptr)
+        unsafe_read(regulario, pointer(v), nb)
+    else
+        unsafe_copy!(pointer(v), convert(Ptr{T}, inptr), n)
+    end
+    io.curptr = inptr + sizeof(T) * n
+    v
+end
+
+@inline function read_array!{T,RR}(v::Array{T}, f::JLDFile{MmapIO},
+                                   rr::ReadRepresentation{T,RR})
+    io = f.io
+    inptr = io.curptr
+    n = length(v)
+    @simd for i = 1:n
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, inptr)
+            @inbounds v[i] = jlconvert(rr, f, inptr, NULL_REFERENCE)
+        end
+        inptr += sizeof(RR)
+    end
+    io.curptr = inptr + sizeof(RR) * n
+    v
+end
+
+@inline function read_compressed_array!{T,RR}(v::Array{T}, f::JLDFile{MmapIO},
+                                              rr::ReadRepresentation{T,RR},
+                                              data_length::Int)
+    io = f.io
+    inptr = io.curptr
+    data = read(ZlibInflateInputStream(unsafe_wrap(Array, Ptr{UInt8}(inptr), data_length); gzip=false))
+    @simd for i = 1:length(v)
+        dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+            @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
+        end
+    end
+    io.curptr = inptr + data_length
+    v
+end
+
+function write_data{S}(io::MmapIO, f::JLDFile, data, odr::S, ::ReferenceFree,
+                       wsession::JLDWriteSession)
+    io = f.io
+    ensureroom(io, sizeof(odr))
+    cp = io.curptr
+    h5convert!(cp, odr, f, data, wsession)
+    io.curptr = cp + sizeof(odr)
+    nothing
+end
+
+function write_data{S}(io::MmapIO, f::JLDFile, data, odr::S, ::HasReferences,
+                       wsession::JLDWriteSession)
+    io = f.io
+    ensureroom(io, sizeof(odr))
+    p = position(io)
+    cp = IndirectPointer(io, p)
+    h5convert!(cp, odr, f, data, wsession)
+    seek(io, p + sizeof(odr))
+    nothing
+end
+
+function raw_write(io::MmapIO, ptr::Ptr{UInt8}, nb::Int)
+    if nb > MMAP_CUTOFF
+        pos = position(io)
+
+        # Ensure that the current page has been flushed to disk
+        msync(io, pos, min(io.endptr - io.curptr, nb))
+
+        # Write to the underlying IOStream
+        regulario = io.f
+        seek(regulario, pos)
+        unsafe_write(regulario, ptr, nb)
+
+        # Invalidate cache of any pages that were just written to
+        msync(io, pos, min(io.n - pos, nb), true)
+
+        # Make sure the mapping is encompasses the written data
+        ensureroom(io, nb + 1)
+
+        # Seek to the place we just wrote
+        seek(io, pos + nb)
+    else
+        unsafe_write(io, ptr, nb)
+    end
+    nothing
+end
+
+write_data{T}(io::MmapIO, f::JLDFile, data::Array{T}, odr::Type{T}, ::ReferenceFree,
+              wsession::JLDWriteSession) =
+    raw_write(io, Ptr{UInt8}(pointer(data)), sizeof(odr) * length(data))
+
+function write_data{T,S}(io::MmapIO, f::JLDFile, data::Array{T}, odr::S, ::ReferenceFree,
+                         wsession::JLDWriteSession)
+    io = f.io
+    ensureroom(io, sizeof(odr) * length(data))
+    cp = io.curptr
+    @simd for i = 1:length(data)
+        @inbounds h5convert!(cp, odr, f, data[i], wsession)
+        cp += sizeof(odr)
+    end
+    io.curptr = cp
+    nothing
+end
+
+function write_data{T,S}(io::MmapIO, f::JLDFile, data::Array{T}, odr::S, ::HasReferences,
+                         wsession::JLDWriteSession)
+    io = f.io
+    ensureroom(io, sizeof(odr) * length(data))
+    p = position(io)
+    cp = IndirectPointer(io, p)
+
+    for i = 1:length(data)
+        if unsafe_isdefined(data, i)
+            @inbounds h5convert!(cp, odr, f, data[i], wsession)
+        else
+            @inbounds h5convert_uninitialized!(cp, odr)
+        end
+        cp += sizeof(odr)
+    end
+
+    seek(io, cp.offset)
+    nothing
+end
+
+#
+# IOStream/BufferedWriter
+#
+
+@inline function read_scalar(f::JLDFile{IOStream}, rr, header_offset::RelOffset)
+    r = Vector{UInt8}(sizeof(rr))
+    unsafe_read(f.io, pointer(r), sizeof(rr))
+    jlconvert(rr, f, pointer(r), header_offset)
+end
+
+@inline function read_compressed_array!{T,RR}(v::Array{T}, f::JLDFile{IOStream},
+                                              rr::ReadRepresentation{T,RR},
+                                              data_length::Int)
+    io = f.io
+    data_offset = position(io)
+    n = length(v)
+    data = read(ZlibInflateInputStream(io; gzip=false), UInt8, sizeof(RR)*n)
+    @simd for i = 1:n
+        dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+            @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
+        end
+    end
+    seek(io, data_offset + data_length)
+    v
+end
+
+@inline function read_array!{T}(v::Array{T}, f::JLDFile{IOStream},
+                                rr::ReadRepresentation{T,T})
+    unsafe_read(f.io, pointer(v), sizeof(T)*length(v))
+    v
+end
+
+@inline function read_array!{T,RR}(v::Array{T}, f::JLDFile{IOStream},
+                                   rr::ReadRepresentation{T,RR})
+    n = length(v)
+    nb = sizeof(RR)*n
+    io = f.io
+    data = read(io, UInt8, nb)
+    @simd for i = 1:n
+        dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+            @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
+        end
+    end
+    v
+end
+
+function write_data{S}(io::BufferedWriter, f::JLDFile, data, odr::S, ::DataMode,
+                       wsession::JLDWriteSession)
+    position = io.position[]
+    h5convert!(Ptr{Void}(pointer(io.buffer, position+1)), odr, f, data, wsession)
+    io.position[] = position + sizeof(odr)
+    nothing
+end
+
+function write_data{T}(io::BufferedWriter, f::JLDFile, data::Array{T}, odr::Type{T}, ::ReferenceFree,
+                       wsession::JLDWriteSession)
+    unsafe_write(io, Ptr{UInt8}(pointer(data)), sizeof(odr) * length(data))
+    nothing
+end
+
+function write_data{T}(io::IOStream, f::JLDFile, data::Array{T}, odr::Type{T}, ::ReferenceFree,
+                       wsession::JLDWriteSession)
+    unsafe_write(io, Ptr{UInt8}(pointer(data)), sizeof(odr) * length(data))
+    nothing
+end
+
+function write_data{T,S}(io::BufferedWriter, f::JLDFile, data::Array{T}, odr::S,
+                         ::DataMode, wsession::JLDWriteSession)
+    position = io.position[]
+    cp = Ptr{Void}(pointer(io.buffer, position+1))
+    @simd for i = 1:length(data)
+        if (isleaftype(T) && isbits(T)) || unsafe_isdefined(data, i)
+            @inbounds h5convert!(cp, odr, f, data[i], wsession)
+        else
+            @inbounds h5convert_uninitialized!(cp, odr)
+        end
+        cp += sizeof(odr)
+    end
+    io.position[] = position + sizeof(odr) * length(data)
+    nothing
+end
+
+function write_data{T,S}(io::IOStream, f::JLDFile, data::Array{T}, odr::S, wm::DataMode,
+                         wsession::JLDWriteSession)
+    nb = sizeof(odr) * length(data)
+    buf = Vector{UInt8}(nb)
+    pos = position(io)
+    cp = Ptr{Void}(pointer(buf))
+    @simd for i = 1:length(data)
+        if (isleaftype(T) && isbits(T)) || unsafe_isdefined(data, i)
+            @inbounds h5convert!(cp, odr, f, data[i], wsession)
+        else
+            @inbounds h5convert_uninitialized!(cp, odr)
+        end
+        cp += sizeof(odr)
+    end
+    # We might seek around in the file as a consequence of writing stuff, so seek back. We
+    # don't need to worry about this for a BufferedWriter, since it will seek back before
+    # writing.
+    !isa(wm, ReferenceFree) && seek(io, pos)
+    write(io, buf)
+    nothing
+end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -16,7 +16,7 @@ function load_dataset(f::JLDFile, offset::RelOffset)
 
     io = f.io
     seek(io, fileoffset(f, offset))
-    cio = begin_checksum(io)
+    cio = begin_checksum_read(io)
     sz = read_obj_start(cio)
     pmax = position(cio) + sz
 
@@ -33,9 +33,9 @@ function load_dataset(f::JLDFile, offset::RelOffset)
         msg = read(cio, HeaderMessage)
         endpos = position(cio) + msg.size
         if msg.msg_type == HM_DATASPACE
-            dataspace = read_dataspace_message(io)
+            dataspace = read_dataspace_message(cio)
         elseif msg.msg_type == HM_DATATYPE
-            datatype_class, datatype_offset = read_datatype_message(io, f, (msg.flags & 2) == 2)
+            datatype_class, datatype_offset = read_datatype_message(cio, f, (msg.flags & 2) == 2)
         elseif msg.msg_type == HM_FILL_VALUE
             (read(cio, UInt8) == 3 && read(cio, UInt8) == 0x09) || throw(UnsupportedFeatureException())
         elseif msg.msg_type == HM_DATA_LAYOUT
@@ -164,16 +164,11 @@ end
 const BOXED_READ_DATASPACE = Ref{Tuple{ReadDataspace,RelOffset,Int,UInt16}}()
 
 # Most types can only be scalars or arrays
-function read_data(f::JLDFile{MmapIO}, rr,
-                   attributes::Union{Vector{ReadAttribute},Void}=nothing)
+function read_data(f::JLDFile, rr, attributes::Union{Vector{ReadAttribute},Void}=nothing)
     dataspace, header_offset, data_length, filter_id = BOXED_READ_DATASPACE[]
     if dataspace.dataspace_type == DS_SCALAR
         filter_id != 0 && throw(UnsupportedFeatureException())
-        io = f.io
-        inptr = io.curptr
-        obj = jlconvert(rr, f, inptr, header_offset)
-        io.curptr = inptr + sizeof(rr)
-        obj
+        read_scalar(f, rr, header_offset)
     elseif dataspace.dataspace_type == DS_SIMPLE
         read_array(f, dataspace, rr, data_length, filter_id, header_offset, attributes)
     else
@@ -182,7 +177,7 @@ function read_data(f::JLDFile{MmapIO}, rr,
 end
 
 # Reference arrays can only be arrays or null dataspace (for Union{} case)
-function read_data(f::JLDFile{MmapIO}, rr::ReadRepresentation{Any,RelOffset},
+function read_data(f::JLDFile, rr::ReadRepresentation{Any,RelOffset},
                    attributes::Vector{ReadAttribute})
     dataspace, header_offset, data_length, filter_id = BOXED_READ_DATASPACE[]
     filter_id != 0 && throw(UnsupportedFeatureException())
@@ -213,23 +208,10 @@ function read_data(f::JLDFile{MmapIO}, rr::ReadRepresentation{Any,RelOffset},
 end
 
 # Types with no payload can only be null dataspace
-function read_data{T}(f::JLDFile{MmapIO}, rr::ReadRepresentation{T,nothing},
-                      attributes::Vector{ReadAttribute})
-    dataspace, header_offset, data_length, filter_id = BOXED_READ_DATASPACE[]
-    filter_id != 0 && throw(UnsupportedFeatureException())
-    dataspace.dataspace_type == DS_NULL || throw(UnsupportedFeatureException())
-
-    dimensions_attr_index = find_dimensions_attr(attributes)
-    if dimensions_attr_index == 0
-        jlconvert(rr, f, Ptr{Void}(0), header_offset)
-    else
-        # dimensions attribute => array of empty type
-        read_empty(rr, f, attributes[dimensions_attr_index], header_offset)
-    end
-end
-
-function read_data{T,S}(f::JLDFile{MmapIO}, rr::ReadRepresentation{T,CustomSerialization{S,nothing}},
-                      attributes::Vector{ReadAttribute})
+function read_data(f::JLDFile,
+                   rr::Union{ReadRepresentation{T,nothing} where T,
+                             ReadRepresentation{T,CustomSerialization{S,nothing}} where {S,T}},
+                   attributes::Vector{ReadAttribute})
     dataspace, header_offset, data_length, filter_id = BOXED_READ_DATASPACE[]
     filter_id != 0 && throw(UnsupportedFeatureException())
     dataspace.dataspace_type == DS_NULL || throw(UnsupportedFeatureException())
@@ -255,10 +237,9 @@ function find_dimensions_attr(attributes::Vector{ReadAttribute})
     dimensions_attr_index
 end
 
-function read_empty{T}(rr::ReadRepresentation{T}, f::JLDFile{MmapIO},
+function read_empty{T}(rr::ReadRepresentation{T}, f::JLDFile,
                     dimensions_attr::ReadAttribute, header_offset::RelOffset)
     io = f.io
-    inptr = io.curptr
     seek(io, dimensions_attr.dataspace.dimensions_offset)
     ndims = read(io, Int)
     seek(io, dimensions_attr.data_offset)
@@ -269,7 +250,6 @@ function read_empty{T}(rr::ReadRepresentation{T}, f::JLDFile{MmapIO},
         end
     end
     header_offset !== NULL_REFERENCE && (f.jloffset[header_offset] = WeakRef(v))
-    io.curptr = inptr
     v
 end
 
@@ -291,6 +271,20 @@ function get_ndims_offset(f::JLDFile, dataspace::ReadDataspace, attributes::Vect
         end
     end
     (ndims, offset)
+end
+
+@inline function read_scalar(f::JLDFile{MmapIO}, rr, header_offset)
+    io = f.io
+    inptr = io.curptr
+    obj = jlconvert(rr, f, inptr, header_offset)
+    io.curptr = inptr + sizeof(rr)
+    obj
+end
+
+@inline function read_scalar(f::JLDFile{IOStream}, rr, header_offset)
+    r = Vector{UInt8}(sizeof(rr))
+    unsafe_read(f.io, pointer(r), sizeof(rr))
+    jlconvert(rr, f, pointer(r), header_offset)
 end
 
 """
@@ -323,44 +317,70 @@ function read_array{T,RR}(f::JLDFile, dataspace::ReadDataspace,
                           filter_id::UInt16, header_offset::RelOffset, 
                           attributes::Union{Vector{ReadAttribute},Void})
     io = f.io
-    inptr = io.curptr
+    data_offset = position(io)
     ndims, offset = get_ndims_offset(f, dataspace, attributes)
     seek(io, offset)
     v = construct_array(io, T, Int(ndims))
     header_offset !== NULL_REFERENCE && (f.jloffset[header_offset] = WeakRef(v))
     n = length(v)
-
+    seek(io, data_offset)
     if filter_id == 1
-        data = read(ZlibInflateInputStream(unsafe_wrap(Array, Ptr{UInt8}(inptr), data_length); gzip=false))
-        @simd for i = 1:n
-            dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
-            if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
-                @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
-            end
+        read_compressed_array!(v, f, rr, data_length)
+    else
+        read_array!(v, f, rr)
+    end
+    v
+end
+
+@inline function read_compressed_array!{T,RR}(v::Array{T}, f::JLDFile{MmapIO},
+                                              rr::ReadRepresentation{T,RR},
+                                              data_length::Int)
+    io = f.io
+    inptr = io.curptr
+    data = read(ZlibInflateInputStream(unsafe_wrap(Array, Ptr{UInt8}(inptr), data_length); gzip=false))
+    @simd for i = 1:length(v)
+        dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+            @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
         end
-        io.curptr = inptr + data_length
-        return v
-    elseif RR === T && isbits(T)
-        nb = n*sizeof(RR)
+    end
+    io.curptr = inptr + data_length
+    v
+end
+
+@inline function read_compressed_array!{T,RR}(v::Array{T}, f::JLDFile{IOStream},
+                                              rr::ReadRepresentation{T,RR},
+                                              data_length::Int)
+    io = f.io
+    data_offset = position(io)
+    n = length(v)
+    data = read(ZlibInflateInputStream(io; gzip=false), UInt8, sizeof(RR)*n)
+    @simd for i = 1:n
+        dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+        if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+            @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
+        end
+    end
+    seek(io, data_offset + data_length)
+    v
+end
+
+@inline function read_array!{T,RR}(v::Array{T}, f::JLDFile{MmapIO},
+                                   rr::ReadRepresentation{T,RR})
+    io = f.io
+    inptr = io.curptr
+    n = length(v)
+    if RR === T && isbits(T)
+        nb = sizeof(RR)*n
         if nb > 1048576 # TODO tweak
             # It turns out that regular IO is faster here (at least on OS X)
             mmapio = f.io
             regulario = mmapio.f
             seek(regulario, inptr - pointer(f.io.arr))
-            if ccall(:ios_readall, UInt,
-                     (Ptr{Void}, Ptr{Void}, UInt), regulario.ios, v, nb) < nb
-                throw(EOFError())
-            end
+            unsafe_read(regulario, pointer(v), nb)
         else
-            unsafe_copy!(pointer(v), convert(Ptr{T}, inptr), Int(n))
+            unsafe_copy!(pointer(v), convert(Ptr{T}, inptr), n)
         end
-    # Would this actually help with performance?
-    # elseif isbits(T)
-    #     @simd for i = 1:n
-    #         jlconvert!(outptr, rr, f, inptr)
-    #         inptr += sizeof(RR)
-    #         outptr += sizeof(T)
-    #     end
     else
         @simd for i = 1:n
             if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, inptr)
@@ -373,6 +393,25 @@ function read_array{T,RR}(f::JLDFile, dataspace::ReadDataspace,
     v
 end
 
+@inline function read_array!{T,RR}(v::Array{T}, f::JLDFile{IOStream},
+                                   rr::ReadRepresentation{T,RR})
+    n = length(v)
+    nb = sizeof(RR)*n
+    io = f.io
+    if RR === T && isbits(T)
+        unsafe_read(io, pointer(v), nb)
+    else
+        data = read(io, UInt8, sizeof(RR)*length(v))
+        @simd for i = 1:n
+            dataptr = Ptr{Void}(pointer(data, sizeof(RR)*(i-1)+1))
+            if !jlconvert_canbeuninitialized(rr) || jlconvert_isinitialized(rr, dataptr)
+                @inbounds v[i] = jlconvert(rr, f, dataptr, NULL_REFERENCE)
+            end
+        end
+    end
+    v
+end
+
 function payload_size_without_storage_message(dataspace::WriteDataspace, datatype::H5Datatype)
     sz = 6 + 4 + sizeof(dataspace) + 4 + sizeof(datatype) + length(dataspace.attributes)*sizeof(HeaderMessage)
     for attr in dataspace.attributes
@@ -381,8 +420,7 @@ function payload_size_without_storage_message(dataspace::WriteDataspace, datatyp
     sz
 end
 
-# Might need to do something else someday for non-mmapped IO
-function write_data{S}(f::JLDFile{MmapIO}, data, odr::S, wsession::JLDWriteSession)
+function write_data{S}(io::MmapIO, f::JLDFile, data, odr::S, wsession::JLDWriteSession)
     io = f.io
     ensureroom(io, sizeof(odr))
     arr = io.arr
@@ -398,11 +436,18 @@ function write_data{S}(f::JLDFile{MmapIO}, data, odr::S, wsession::JLDWriteSessi
     arr # Keep old array rooted until the end
 end
 
+function write_data{S}(io::BufferedWriter, f::JLDFile, data, odr::S, wsession::JLDWriteSession)
+    position = io.position[]
+    h5convert!(Ptr{Void}(pointer(io.buffer, position+1)), odr, f, data, wsession)
+    io.position[] = position + sizeof(odr)
+    nothing
+end
+
 # Like isdefined, but assumes arr is a pointer array, and can be inlined
 unsafe_isdefined(arr::Array, i::Int) =
     unsafe_load(Ptr{Ptr{Void}}(pointer(arr)+(i-1)*sizeof(Ptr{Void}))) != Ptr{Void}(0)
 
-function write_data{T,S}(f::JLDFile{MmapIO}, data::Array{T}, odr::S,
+function write_data{T,S}(io::MmapIO, f::JLDFile, data::Array{T}, odr::S,
                          wsession::JLDWriteSession)
     io = f.io
     ensureroom(io, sizeof(odr) * length(data))
@@ -426,6 +471,47 @@ function write_data{T,S}(f::JLDFile{MmapIO}, data::Array{T}, odr::S,
     seek(io, p + sizeof(odr) * length(data))
 
     arr # Keep old array rooted until the end
+end
+
+function write_data{T,S}(io::BufferedWriter, f::JLDFile, data::Array{T}, odr::S,
+                         wsession::JLDWriteSession)
+    position = io.position[]
+    cp = pointer(io.buffer, position+1)
+    @simd for i = 1:length(data)
+        if (isleaftype(T) && isbits(T)) || unsafe_isdefined(data, i)
+            @inbounds h5convert!(cp, odr, f, data[i], wsession)
+        else
+            @inbounds h5convert_uninitialized!(cp, odr)
+        end
+        cp += sizeof(odr)
+    end
+    io.position[] = position + sizeof(odr) * length(data)
+    nothing
+end
+
+function write_data{T,S}(io::IOStream, f::JLDFile, data::Array{T}, odr::S,
+                         wsession::JLDWriteSession)
+    nb = sizeof(odr) * length(data)
+    if odr === T && isbits(T)
+        unsafe_write(io, pointer(data), nb)
+    else
+        buf = Vector{UInt8}(nb)
+        pos = position(io)
+        cp = pointer(buf)
+        @simd for i = 1:length(data)
+            if (isleaftype(T) && isbits(T)) || unsafe_isdefined(data, i)
+                @inbounds h5convert!(cp, odr, f, data[i], wsession)
+            else
+                @inbounds h5convert_uninitialized!(cp, odr)
+            end
+            cp += sizeof(odr)
+        end
+        # We might seek around in the file as a consequence of writing stuff, so seek back. We
+        # don't need to worry about this for a BufferedWriter, since it will seek back before
+        # writing.
+        seek(io, pos)
+        write(io, buf)
+    end
 end
 
 function deflate_data{T,S}(f::JLDFile, data::Array{T}, odr::S, wsession::JLDWriteSession)
@@ -465,7 +551,7 @@ function write_dataset{T,S}(f::JLDFile, dataspace::WriteDataspace, datatype::H5D
         push!(wsession.objects, data)
     end
 
-    cio = begin_checksum(io, fullsz - 4)
+    cio = begin_checksum_write(io, fullsz - 4)
     write_object_header_and_dataspace_message(cio, f, psz, dataspace)
     write_datatype_message(cio, datatype)
 
@@ -473,7 +559,7 @@ function write_dataset{T,S}(f::JLDFile, dataspace::WriteDataspace, datatype::H5D
     if layout_class == LC_COMPACT_STORAGE
         write(cio, CompactStorageMessage(datasz))
         if datasz != 0
-            write_data(f, data, odr, wsession)
+            write_data(cio, f, data, odr, wsession)
         end
         write(io, end_checksum(cio))
     elseif layout_class == LC_CHUNKED_STORAGE
@@ -489,7 +575,7 @@ function write_dataset{T,S}(f::JLDFile, dataspace::WriteDataspace, datatype::H5D
         write(io, end_checksum(cio))
 
         f.end_of_data += datasz
-        write_data(f, data, odr, wsession)
+        write_data(io, f, data, odr, wsession)
     end
 
     h5offset(f, header_offset)
@@ -510,12 +596,12 @@ function write_dataset{S}(f::JLDFile, dataspace::WriteDataspace, datatype::H5Dat
         push!(wsession.objects, data)
     end
 
-    cio = begin_checksum(io, fullsz - 4)
+    cio = begin_checksum_write(io, fullsz - 4)
     write_object_header_and_dataspace_message(cio, f, psz, dataspace)
     write_datatype_message(cio, datatype)
     write(cio, CompactStorageMessage(datasz))
     if datasz != 0
-        write_data(f, data, odr, wsession)
+        write_data(cio, f, data, odr, wsession)
     end
     write(io, end_checksum(cio))
 
@@ -543,7 +629,7 @@ function write_object_header_and_dataspace_message(cio::IO, f::JLDFile, psz::Int
 end
 
 function write_datatype_message(cio::IO, datatype::H5Datatype)
-    write(cio, HeaderMessage(HM_DATATYPE, sizeof(datatype), 1+2*isa(datatype, CommittedDatatype)))
+    write(cio, HeaderMessage(HM_DATATYPE, sizeof(datatype), 1 | (2*isa(datatype, CommittedDatatype))))
     write(cio, datatype)
 end
 

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -255,7 +255,7 @@ function commit(f::JLDFile, dt::H5Datatype, attrs::Tuple{Vararg{WrittenAttribute
     seek(io, offset)
     f.end_of_data = offset + sz + 4
 
-    cio = begin_checksum(io, sz)
+    cio = begin_checksum_write(io, sz)
     write(cio, ObjectStart(size_flag(psz)))
     write_size(cio, psz)
     write(cio, HeaderMessage(HM_DATATYPE, sizeof(dt), 64))
@@ -264,7 +264,6 @@ function commit(f::JLDFile, dt::H5Datatype, attrs::Tuple{Vararg{WrittenAttribute
         write(cio, HeaderMessage(HM_ATTRIBUTE, sizeof(attr), 0))
         write_attribute(cio, f, attr, f.datatype_wsession)
     end
-    seek(io, offset + sz)
     write(io, end_checksum(cio))
 end
 
@@ -272,7 +271,7 @@ end
 function read_committed_datatype(f::JLDFile, cdt::CommittedDatatype)
     io = f.io
     seek(io, fileoffset(f, cdt.header_offset))
-    cio = begin_checksum(io)
+    cio = begin_checksum_read(io)
     sz = read_obj_start(cio)
     pmax = position(cio) + sz
 

--- a/src/global_heaps.jl
+++ b/src/global_heaps.jl
@@ -85,7 +85,7 @@ function write_heap_object(f::JLDFile, odr, data, wsession::JLDWriteSession)
 
     # Write data
     seek(io, objoffset + 8+sizeof(Length))
-    write_data(io, f, data, odr, wsession) # Object data
+    write_data(io, f, data, odr, datamode(odr), wsession) # Object data
 
     GlobalHeapID(h5offset(f, gh.offset), index)
 end

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -24,8 +24,8 @@ function define_packed(ty::DataType)
     end
 
     @eval begin
-        @inline Base.write(io::MmapIO, x::$ty) = _write(io, x)
-        @inline Base.read(io::MmapIO, x::Type{$ty}) = _read(io, x)
+        @inline Base.write(io::Union{MmapIO,BufferedWriter}, x::$ty) = _write(io, x)
+        @inline Base.read(io::Union{MmapIO,BufferedReader}, x::Type{$ty}) = _read(io, x)
         function Base.read(io::IO, ::Type{$ty})
             $(Expr(:new, ty, [:(read(io, $(ty.types[i]))) for i = 1:length(packed_offsets)]...))
         end

--- a/src/mmapio.jl
+++ b/src/mmapio.jl
@@ -2,8 +2,13 @@
 # MmapIO
 #
 # An IO built on top of mmap to avoid the overhead of ordinary disk IO
-const MMAP_GROW_SIZE = 2^24
-const FILE_GROW_SIZE = 2^18
+if is_windows()
+    const MMAP_GROW_SIZE = 2^19
+    const FILE_GROW_SIZE = 2^19
+else
+    const MMAP_GROW_SIZE = 2^24
+    const FILE_GROW_SIZE = 2^18
+end
 
 const Plain = Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128,Float16,Float32,
                     Float64}
@@ -14,9 +19,79 @@ const PlainType = Union{Type{Int16},Type{Int32},Type{Int64},Type{Int128},Type{UI
 mutable struct MmapIO <: IO
     f::IOStream
     write::Bool
-    arr::Vector{UInt8}
+    n::Int
+    startptr::Ptr{Void}
     curptr::Ptr{Void}
     endptr::Ptr{Void}
+    @static if is_windows()
+        mapping::Ptr{Void}
+    end
+end
+
+if is_unix()
+    function mmap!(io::MmapIO, n::Int)
+        oldptr = io.startptr
+        newptr = ccall(:jl_mmap, Ptr{Void}, (Ptr{Void}, Csize_t, Cint, Cint, Cint, Int64),
+                       C_NULL, n, Mmap.PROT_READ | (io.write*Mmap.PROT_WRITE),
+                       Mmap.MAP_SHARED, fd(io.f), 0)
+        io.n = n
+        io.curptr += newptr - oldptr
+        io.startptr = newptr
+    end
+
+    munmap(io::MmapIO) =
+        systemerror("munmap",
+                    ccall(:munmap, Cint, (Ptr{Void}, Int), io.startptr, io.n) != 0)
+
+    function msync(io::MmapIO, offset::Integer=0, len::Integer=UInt(io.endptr - io.startptr),
+                   invalidate::Bool=false)
+        # shift `offset` to start of page boundary
+        offset_page::Int64 = div(offset, Mmap.PAGESIZE) * Mmap.PAGESIZE
+        # add (offset - offset_page) to `len` to get total length of memory-mapped region
+        mmaplen::Int64 = (offset - offset_page) + len
+        systemerror("msync",
+                    ccall(:msync, Cint, (Ptr{Void}, Csize_t, Cint),
+                          io.startptr + offset_page, mmaplen,
+                          invalidate ? Mmap.MS_INVALIDATE : Mmap.MS_SYNC) != 0)
+    end
+elseif is_windows()
+    const DWORD = Culong
+    function mmap!(io::MmapIO, n::Int)
+        oldptr = io.startptr
+        mapping = ccall(:CreateFileMappingW, stdcall, Ptr{Void},
+                        (Cptrdiff_t, Ptr{Void}, DWORD, DWORD, DWORD, Ptr{Void}),
+                        Mmap.gethandle(io.f), C_NULL,
+                        io.write ? Mmap.PAGE_READWRITE : Mmap.PAGE_READONLY, n >> 32,
+                        n % UInt32, C_NULL)
+        systemerror("CreateFileMappingW", mapping == C_NULL)
+        newptr = ccall(:MapViewOfFile, stdcall, Ptr{Void},
+                       (Ptr{Void}, DWORD, DWORD, DWORD, Csize_t),
+                        mapping, io.write ? Mmap.FILE_MAP_WRITE : Mmap.FILE_MAP_READ, 0, 0,
+                        n)
+        systemerror("MapViewOfFile", newptr == C_NULL)
+        io.n = n
+        io.curptr += newptr - oldptr
+        io.mapping = mapping
+        io.startptr = newptr
+    end
+
+    function munmap(io::MmapIO)
+        systemerror("UnmapViewOfFile",
+                    ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Void},), io.startptr) == 0)
+        systemerror("CloseHandle",
+                    ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), io.mapping) == 0)
+    end
+
+    function msync(io::MmapIO, offset::Integer=0, len::Integer=UInt(io.endptr - io.startptr),
+                   invalidate::Bool=false)
+        # shift `offset` to start of page boundary
+        offset_page::Int64 = div(offset, Mmap.PAGESIZE) * Mmap.PAGESIZE
+        # add (offset - offset_page) to `len` to get total length of memory-mapped region
+        mmaplen::Int64 = (offset - offset_page) + len
+        systemerror("FlushViewOfFile",
+                    ccall(:FlushViewOfFile, stdcall, Cint,
+                          (Ptr{Void}, Csize_t), io.startptr + offset_page, mmaplen) == 0)
+    end
 end
 
 function MmapIO(fname::AbstractString, write::Bool, create::Bool, truncate::Bool)
@@ -24,9 +99,17 @@ function MmapIO(fname::AbstractString, write::Bool, create::Bool, truncate::Bool
 
     f = open(fname, true, write, create, truncate, false)
     initialsz = truncate ? 0 : filesize(fname)
-    arr = Mmap.mmap(f, Vector{UInt8}, (initialsz + MMAP_GROW_SIZE,); grow=false)
-    ptr = Ptr{Void}(pointer(arr))
-    io = MmapIO(f, write, arr, ptr, ptr + initialsz)
+    n = initialsz + (write ? MMAP_GROW_SIZE : 0)
+
+    @static if is_windows()
+        io = MmapIO(f, write, 0, C_NULL, C_NULL, C_NULL, C_NULL)
+    else
+        io = MmapIO(f, write, 0, C_NULL, C_NULL, C_NULL)
+    end
+    mmap!(io, n)
+    io.endptr = io.startptr + initialsz
+
+    io
 end
 
 Base.show(io::IO, ::MmapIO) = print(io, "MmapIO")
@@ -43,17 +126,19 @@ else
 end
 
 function Base.resize!(io::MmapIO, newend::Ptr{Void})
-    # Resize file
-    ptr = pointer(io.arr)
-    newsz = Int(max(newend - ptr, io.curptr - ptr + FILE_GROW_SIZE))
-    grow(io.f, newsz)
+    io.write || throw(EOFError())
 
-    if newsz > length(io.arr)
+    # Resize file
+    ptr = io.startptr
+    newsz = Int(max(newend - ptr, io.curptr - ptr + FILE_GROW_SIZE))
+    @static if !is_windows()
+        grow(io.f, newsz)
+    end
+
+    if newsz > io.n
         # If we have not mapped enough memory, map more
-        io.arr = Mmap.mmap(io.f, Vector{UInt8}, (newsz + MMAP_GROW_SIZE,); grow=false)
-        newptr = pointer(io.arr)
-        io.curptr += newptr - ptr
-        ptr = newptr
+        munmap(io)
+        ptr = mmap!(io, max(newsz, io.n + MMAP_GROW_SIZE))
     end
 
     # Set new end
@@ -69,11 +154,16 @@ end
     nothing
 end
 
-Base.truncate(io::MmapIO, pos) = truncate(io.f, pos)
+function truncate_and_close(io::MmapIO, endpos::Integer)
+    io.write && msync(io)
+    munmap(io)
+    truncate(io.f, endpos)
+    close(io.f)
+end
 
 function Base.close(io::MmapIO)
-    io.write && Mmap.sync!(io.arr)
-    finalize(io.arr)
+    io.write && msync(io)
+    munmap(io)
     close(io.f)
 end
 
@@ -139,17 +229,43 @@ function read_bytestring(io::MmapIO)
     str
 end
 
-function Base.seek(io::MmapIO, offset::Integer)
-    io.curptr = pointer(io.arr) + offset
+@inline function Base.seek(io::MmapIO, offset::Integer)
+    if io.startptr + offset > io.endptr
+        resize!(io, io.startptr + offset)
+    end
+    io.curptr = io.startptr + offset
     nothing
 end
 
-function Base.skip(io::MmapIO, offset::Integer)
+@inline function Base.skip(io::MmapIO, offset::Integer)
+    if io.curptr + offset > io.endptr
+        resize!(io, io.curptr + offset)
+    end
     io.curptr += offset
     nothing
 end
 
-Base.position(io::MmapIO) = Int64(io.curptr - pointer(io.arr))
+Base.position(io::MmapIO) = Int64(io.curptr - io.startptr)
+
+"""
+    IndirectPointer
+
+When writing data, we may need to enlarge the memory mapping, which would invalidate any
+memory addresses arising from the old `mmap` pointer. `IndirectPointer` holds a pointer to
+the `startptr` field of an MmapIO, and the offset relative to that pointer. It defers
+computing a memory address until converted to a Ptr{T}, so the memory mapping can be
+enlarged and addresses will remain valid.
+"""
+struct IndirectPointer
+    ptr::Ptr{Ptr{Void}}
+    offset::Int
+end
+
+function IndirectPointer(io::MmapIO, offset::Integer=position(io))
+    IndirectPointer(pointer_from_objref(io) + fieldoffset(MmapIO, 4), offset)
+end
+Base.:+(x::IndirectPointer, y::Integer) = IndirectPointer(x.ptr, x.offset+y)
+Base.convert{T}(::Type{Ptr{T}}, x::IndirectPointer) = Ptr{T}(unsafe_load(x.ptr) + x.offset)
 
 # We sometimes need to compute checksums. We do this by first calling begin_checksum when
 # starting to handle whatever needs checksumming, and calling end_checksum afterwards. Note
@@ -174,5 +290,5 @@ end
 function end_checksum(io::MmapIO)
     @inbounds v = CHECKSUM_POS[NCHECKSUM[]]
     NCHECKSUM[] -= 1
-    Lookup3.hash(io.arr, v+1, position(io) - v)
+    Lookup3.hash(Ptr{UInt8}(io.startptr + v), position(io) - v)
 end

--- a/src/superblock.jl
+++ b/src/superblock.jl
@@ -18,14 +18,14 @@ Base.sizeof(::Union{Type{Superblock},Superblock}) =
     12+sizeof(RelOffset)*4+4
 
 function Base.read(io::IO, ::Type{Superblock})
-    cio = begin_checksum(io)
+    cio = begin_checksum_read(io)
 
     # Signature
     signature = read(cio, UInt64)
     signature == SUPERBLOCK_SIGNATURE || throw(InvalidDataException())
 
     # Version
-    version  = read(cio, UInt8)
+    version = read(cio, UInt8)
     version == 2 || throw(UnsupportedVersionException())
 
     # Size of offsets and size of lengths
@@ -51,7 +51,7 @@ function Base.read(io::IO, ::Type{Superblock})
 end
 
 function Base.write(io::IO, s::Superblock)
-    cio = begin_checksum(io, sizeof(s))
+    cio = begin_checksum_write(io, 8+4+4*sizeof(RelOffset))
     write(cio, SUPERBLOCK_SIGNATURE::UInt64)    # Signature
     write(cio, UInt8(2))                        # Version
     write(cio, UInt8(8))                        # Size of offsets

--- a/test/finalization.jl
+++ b/test/finalization.jl
@@ -1,15 +1,25 @@
 using JLD2, Base.Test
 
 # Make sure that the file gets written properly regardless of the order in which the
-# MmapIO and JLDFile are finalized
+# IO and JLDFile are finalized
 fn = joinpath(tempdir(), "test.jld")
-for order in [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
+
+f = jldopen(fn, "w")
+close(f)
+if isa(f, JLD2.JLDFile{IOStream})
+    objorder = [[1, 2], [2, 1]]
+else
+    objorder = [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
+end
+
+for order in objorder
     f = jldopen(fn, "w")
     write(f, "x", 1:10)
-    objs = [f, f.io.f, f.io.arr]
-    finalize(objs[order[1]])
-    finalize(objs[order[2]])
-    finalize(objs[order[3]])
+
+    objs = isa(f, JLD2.JLDFile{IOStream}) ? [f, f.io] : [f, f.io.f, f.io.arr]
+    for i in order
+        finalize(objs[i])
+    end
 
     f = jldopen(fn, "r")
     @test read(f, "x") == 1:10

--- a/test/finalization.jl
+++ b/test/finalization.jl
@@ -6,17 +6,12 @@ fn = joinpath(tempdir(), "test.jld")
 
 f = jldopen(fn, "w")
 close(f)
-if isa(f, JLD2.JLDFile{IOStream})
-    objorder = [[1, 2], [2, 1]]
-else
-    objorder = [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
-end
 
-for order in objorder
+for order in [[1, 2], [2, 1]]
     f = jldopen(fn, "w")
     write(f, "x", 1:10)
 
-    objs = isa(f, JLD2.JLDFile{IOStream}) ? [f, f.io] : [f, f.io.f, f.io.arr]
+    objs = isa(f, JLD2.JLDFile{IOStream}) ? [f, f.io] : [f, f.io.f]
     for i in order
         finalize(objs[i])
     end

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -6,31 +6,33 @@ function writeloop(f, sz)
     end
 end
 
-# Force growing an MmapIO
-name, io = mktemp()
-f = JLD2.MmapIO(name, true, true, true)
-close(io)
-sz = JLD2.MMAP_GROW_SIZE+5
-writeloop(f, sz)
-truncate(f.f, position(f))
-close(f)
+if !is_windows()
+    # Force growing an MmapIO
+    name, io = mktemp()
+    f = JLD2.MmapIO(name, true, true, true)
+    close(io)
+    sz = JLD2.MMAP_GROW_SIZE+5
+    writeloop(f, sz)
+    truncate(f.f, position(f))
+    close(f)
 
-@test filesize(name) == sz
-f = open(name)
-rd = read(f, UInt8, sz)
-@test all(rd .== UInt8(6))
-close(f)
+    @test filesize(name) == sz
+    f = open(name)
+    rd = read(f, UInt8, sz)
+    @test all(rd .== UInt8(6))
+    close(f)
 
-f = JLD2.MmapIO(name, true, true, true)
-write(f, rd)
-truncate(f.f, position(f))
-close(f)
+    f = JLD2.MmapIO(name, true, true, true)
+    write(f, rd)
+    truncate(f.f, position(f))
+    close(f)
 
-@test filesize(name) == sz
-f = open(name)
-rd = read(f, UInt8, sz)
-@test all(rd .== UInt8(6))
-close(f)
+    @test filesize(name) == sz
+    f = open(name)
+    rd = read(f, UInt8, sz)
+    @test all(rd .== UInt8(6))
+    close(f)
+end
 
 @test JLD2.size_flag(1) === UInt8(0)
 @test JLD2.size_flag(256) === UInt8(1)

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -6,33 +6,29 @@ function writeloop(f, sz)
     end
 end
 
-if !is_windows()
-    # Force growing an MmapIO
-    name, io = mktemp()
-    f = JLD2.MmapIO(name, true, true, true)
-    close(io)
-    sz = JLD2.MMAP_GROW_SIZE+5
-    writeloop(f, sz)
-    truncate(f.f, position(f))
-    close(f)
+# Force growing an MmapIO
+name, io = mktemp()
+f = JLD2.MmapIO(name, true, true, true)
+close(io)
+sz = JLD2.MMAP_GROW_SIZE+5
+writeloop(f, sz)
+JLD2.truncate_and_close(f, position(f))
 
-    @test filesize(name) == sz
-    f = open(name)
-    rd = read(f, UInt8, sz)
-    @test all(rd .== UInt8(6))
-    close(f)
+@test filesize(name) == sz
+f = open(name)
+rd = read(f, UInt8, sz)
+@test all(rd .== UInt8(6))
+close(f)
 
-    f = JLD2.MmapIO(name, true, true, true)
-    write(f, rd)
-    truncate(f.f, position(f))
-    close(f)
+f = JLD2.MmapIO(name, true, true, true)
+write(f, rd)
+JLD2.truncate_and_close(f, position(f))
 
-    @test filesize(name) == sz
-    f = open(name)
-    rd = read(f, UInt8, sz)
-    @test all(rd .== UInt8(6))
-    close(f)
-end
+@test filesize(name) == sz
+f = open(name)
+rd = read(f, UInt8, sz)
+@test all(rd .== UInt8(6))
+close(f)
 
 @test JLD2.size_flag(1) === UInt8(0)
 @test JLD2.size_flag(256) === UInt8(1)
@@ -72,4 +68,3 @@ seek(buf, 0)
 @test JLD2.size_size(256) === 2
 @test JLD2.size_size(65536) === 4
 @test JLD2.size_size(UInt64(4294967296)) === 8
-

--- a/test/rw.jl
+++ b/test/rw.jl
@@ -311,13 +311,13 @@ macro check(fid, sym)
                 Base.show_backtrace(STDOUT, catch_backtrace())
                 error("error reading ", $(string(sym)))
             end
-            if !iseq(tmp, $sym)
-                written = $sym
-                error("For ", $(string(sym)), ", read value $tmp does not agree with written value $written")
-            end
             written_type = typeof($sym)
             if typeof(tmp) != written_type
                 error("For ", $(string(sym)), ", read type $(typeof(tmp)) does not agree with written type $(written_type)")
+            end
+            if !iseq(tmp, $sym)
+                written = $sym
+                error("For ", $(string(sym)), ", read value $tmp does not agree with written value $written")
             end
         end
     end
@@ -356,8 +356,8 @@ abstract type UnexportedT end
 end
 
 println(fn)
-for compress in [false, true]
-    fid = jldopen(fn, "w", compress=compress)
+for ioty in (is_windows() ? [IOStream] : [JLD2.MmapIO, IOStream]), compress in [false, true]
+    fid = jldopen(fn, true, true, true, ioty, compress=compress)
     @time begin
     @write fid x
     @write fid A

--- a/test/rw.jl
+++ b/test/rw.jl
@@ -356,7 +356,7 @@ abstract type UnexportedT end
 end
 
 println(fn)
-for ioty in (is_windows() ? [IOStream] : [JLD2.MmapIO, IOStream]), compress in [false, true]
+for ioty in [JLD2.MmapIO, IOStream], compress in [false, true]
     fid = jldopen(fn, true, true, true, ioty, compress=compress)
     @time begin
     @write fid x
@@ -471,7 +471,7 @@ for ioty in (is_windows() ? [IOStream] : [JLD2.MmapIO, IOStream]), compress in [
     end
     close(fid)
 
-    fidr = jldopen(fn, "r")
+    fidr = jldopen(fn, false, false, false, ioty)
     @time begin
     @check fidr x
     @check fidr A


### PR DESCRIPTION
Originally, I tried to build an `mmap`-free backend, but it was incredibly slow because I can't avoid allocating lots and lots of memory. So instead, I just got the existing `mmap` backend to work on Windows. I left around the `mmap`-free backend, because it works and it might be good to have someday.