### PR TITLE
Fix #26

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -34,7 +34,7 @@ end
 define_packed(AttributeHeader)
 
 Base.sizeof(attr::WrittenAttribute) = 8 + symbol_length(attr.name) + 1 + sizeof(attr.datatype) + sizeof(attr.dataspace) +
-                                     numel(attr.dataspace) * sizeof(objodr(attr.data))
+                                     numel(attr.dataspace) * odr_sizeof(objodr(attr.data))
 
 function write_attribute(io::IO, f::JLDFile, attr::WrittenAttribute, wsession::JLDWriteSession)
     namelen = symbol_length(attr.name)

--- a/src/global_heaps.jl
+++ b/src/global_heaps.jl
@@ -17,7 +17,7 @@ heap_object_length(data::AbstractArray) = length(data)
 heap_object_length(::Any) = 1
 
 function write_heap_object(f::JLDFile, odr, data, wsession::JLDWriteSession)
-    psz = sizeof(odr)*heap_object_length(data)
+    psz = odr_sizeof(odr)*heap_object_length(data)
     objsz = 8 + sizeof(Length) + psz
     objsz += 8 - mod1(objsz, 8)
 
@@ -127,8 +127,8 @@ function read_heap_object{T,RR}(f::JLDFile, hid::GlobalHeapID, rr::ReadRepresent
     end
     seek(io, gh.objects[hid.index]+8)
     len = Int(read(io, Length))
-    n = div(len, sizeof(RR))
-    len == n * sizeof(RR) || throw(InvalidDataException())
+    n = div(len, odr_sizeof(RR))
+    len == n * odr_sizeof(RR) || throw(InvalidDataException())
 
     read_array!(Vector{T}(n), f, rr)
 end


### PR DESCRIPTION
Replaces `sizeof` with `odr_sizeof` when the argument is an ODR. This is probably a good idea generally, since otherwise something weird might happen if someone redefined `sizeof` on their type.

As best as I can tell, what happened with #26 is that, after loading FixedPointNumbers, [this line](https://github.com/simonster/JLD2.jl/blob/3f700ab5b9beb0cda3e974136b3e62aacd867c8f/src/data.jl#L1332) would call `sizeof(Vlen{String})` and get 24 (which is what would be returned by the method defined in Base) rather than 16 (which is what should be returned by [this definition](https://github.com/simonster/JLD2.jl/blob/3f700ab5b9beb0cda3e974136b3e62aacd867c8f/src/data.jl#L21) earlier in the file, and is what is returned if you call `sizeof(JLD2.Vlen{String})` from the REPL). This made JLD2 skip 8 bytes between writing a string and writing the next field in an object. Apparently, when FixedPointNumbers defined a new method of `sizeof`, this made the generated function forget about the methods defined in JLD2. The errant behavior is sensitive to many things: precompilation must be enabled, JLD2 must be loaded before FixedPointNumbers, and `sizeof(JLD2.Vlen{String})` must not be called manually before it is called from the generated function. The documentation for generated functions is carefully written so that it is ambiguous whether or not this is a bug in Julia.