### PR TITLE
add get() and get!() for JLDFile and Group

### DIFF
--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -332,8 +332,10 @@ Base.isempty(f::JLDFile) = isempty(f.root_group)
 Base.keys(f::JLDFile) = filter!(x->x != "_types", keys(f.root_group))
 Base.get(default::Function, f::Union{JLDFile, Group}, name::AbstractString) = 
     haskey(f, name) ? f[name] : default()
-Base.get(f::Union{JLDFile, Group}, name::AbstractString, default) = haskey(f, name) ? f[name] : default
-Base.get!(f::Union{JLDFile, Group}, name::AbstractString, default) = get!(() -> default, f, name)
+Base.get(f::Union{JLDFile, Group}, name::AbstractString, default) = 
+    haskey(f, name) ? f[name] : default
+Base.get!(f::Union{JLDFile, Group}, name::AbstractString, default) = 
+    get!(() -> default, f, name)
 function Base.get!(default::Function, f::Union{JLDFile, Group}, name::AbstractString)
     if haskey(f, name)
         return f[name]

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -330,6 +330,19 @@ Base.setindex!(f::JLDFile, obj, name::AbstractString) = (f.root_group[name] = ob
 Base.haskey(f::JLDFile, name::AbstractString) = haskey(f.root_group, name)
 Base.isempty(f::JLDFile) = isempty(f.root_group)
 Base.keys(f::JLDFile) = filter!(x->x != "_types", keys(f.root_group))
+Base.get(default::Function, f::Union{JLDFile, Group}, name::AbstractString) = 
+    haskey(f, name) ? f[name] : default()
+Base.get(f::Union{JLDFile, Group}, name::AbstractString, default) = haskey(f, name) ? f[name] : default
+Base.get!(f::Union{JLDFile, Group}, name::AbstractString, default) = get!(() -> default, f, name)
+function Base.get!(default::Function, f::Union{JLDFile, Group}, name::AbstractString)
+    if haskey(f, name)
+        return f[name]
+    else
+        default_value = default()
+        f[name] = default_value
+        return default_value
+    end
+end
 
 function Base.close(f::JLDFile)
     if f.n_times_opened != 1

--- a/test/groups.jl
+++ b/test/groups.jl
@@ -15,6 +15,33 @@ JLD2.Group(f, "group_with_one_group_child/empty_group")
 @test !isempty(read(f, "group_with_one_group_child"))
 @test_throws ArgumentError JLD2.Group(f, "test_group_4")
 @test_throws ArgumentError write(f, "test_group_4/contained_group", 0)
+@test !haskey(f, "path_that_does_not_exist")
+@test get(f, "path_that_does_not_exist", 2.0) == 2.0
+@test get!(f, "path_created_by_get!", "x") == "x"
+@test f["path_created_by_get!"] == "x"
+@test get(JLD2.Group(f, "test_group_5"), "path_that_does_not_exist", 3.0) == 3.0
+@test get!(f["test_group_5"], "path_created_by_get!", 4.0) == 4.0
+@test f["test_group_5"]["path_created_by_get!"] == 4.0
+
+# Test that the default element constructor is called only when necessary
+# First, we'll access a group which *does* exist, so the default constructor is not called:
+@test get(() -> error("this should not be called because the key exists"), f["test_group_5"], "path_created_by_get!") == 4.0
+
+# Then we'll access a few keys that do not exist, and verify that the default
+# constructor was called:
+default_called = false
+get(f, "path_that_does_not_exist") do
+    global default_called
+    default_called = true
+end
+@test default_called
+
+default_called = false
+get!(JLD2.Group(f, "test_group_6"), "path_created_by_get!") do
+    global default_called
+    default_called = true
+end
+@test default_called
 close(f)
 
 f = jldopen(fn, "r")
@@ -46,6 +73,17 @@ f = jldopen(fn, "r")
 @test !isempty(read(f, "test_group_1"))
 @test isempty(read(f, "empty_group"))
 @test isempty(read(f, "group_with_one_group_child/empty_group"))
+
+@test get(f, "path_that_does_not_exist", 1.0) == 1.0
+@test get(f["test_group_5"], "path_that_does_not_exist", 1.0) == 1.0
+@test f["test_group_5"]["path_created_by_get!"] == 4.0
+
+# Throws an ArgumentError because the element doesn't exist and cannot
+# be created for a read-only file:
+@test_throws ArgumentError get!(f, "path_that_does_not_exist", 1.0)
+@test_throws ArgumentError get!(f["test_group_5"], "path_that_does_not_exist", 1.0)
+# Does not throw an ArgumentError because the element does exist:
+@test get!(f["test_group_1"], "x1") == 1
 
 # Make sure printing doesn't error
 show(IOBuffer(), f)

--- a/test/groups.jl
+++ b/test/groups.jl
@@ -83,7 +83,7 @@ f = jldopen(fn, "r")
 @test_throws ArgumentError get!(f, "path_that_does_not_exist", 1.0)
 @test_throws ArgumentError get!(f["test_group_5"], "path_that_does_not_exist", 1.0)
 # Does not throw an ArgumentError because the element does exist:
-@test get!(f["test_group_1"], "x1") == 1
+@test get!(f["test_group_1"], "x1", 2) == 1
 
 # Make sure printing doesn't error
 show(IOBuffer(), f)


### PR DESCRIPTION
This PR implements `get()` and `get!()` for JLDFile and Group. Following the example from Base's `dict.jl`, it implements:

```
get(f::Union{JLDFile, Group}, name::AbstractString, default)
get!(f::Union{JLDFile, Group}, name::AbstractString, default)  # mutates f to add the given key
get(default_generator::Function, f::Union{JLDFile, Group}, name::AbstractString) # calls default_generator() to generate the default value if `name` not found
get!(default_generator::Function, f::Union{JLDFile, Group}, name::AbstractString)  # mutates f to add the given key created by calling `default_generator()` if `name` not found
```

This is somewhat suboptimal because it will perform the key lookup twice: once to check if the key is present and once to actually retrieve the element. Is that OK? This could be improved as a future optimization without changing the public API. 

