### PR TITLE
Fix for SimpleVector unexported on 0.7

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -1024,9 +1024,9 @@ end
 
 ## SimpleVectors
 
-writeas(::Type{SimpleVector}) = Vector{Any}
-wconvert(::Type{Vector{Any}}, x::SimpleVector) = Any[x for x in x]
-rconvert(::Type{SimpleVector}, x::Vector{Any}) = Core.svec(x...)
+writeas(::Type{Core.SimpleVector}) = Vector{Any}
+wconvert(::Type{Vector{Any}}, x::Core.SimpleVector) = Any[x for x in x]
+rconvert(::Type{Core.SimpleVector}, x::Vector{Any}) = Core.svec(x...)
 
 ## Dicts
 

--- a/test/rw.jl
+++ b/test/rw.jl
@@ -263,7 +263,7 @@ cyclicobject.x = cyclicobject
 
 # SimpleVector
 simplevec = Core.svec(1, 2, Int64, "foo")
-iseq(x::SimpleVector, y::SimpleVector) = collect(x) == collect(y)
+iseq(x::Core.SimpleVector, y::Core.SimpleVector) = collect(x) == collect(y)
 
 # JLD issue #243
 # Type that overloads != so that it is not boolean


### PR DESCRIPTION
Fixes the specific issue noted in https://github.com/simonster/JLD2.jl/issues/61#issuecomment-376883882, which is due to `SimpleVector` being unexported in 0.7. cc @kafisatz