### PR TITLE
0.7compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
   - 0.7
   - nightly
+
 matrix:
   fast_finish: true
   allow_failures:
     - julia: nightly
+
 notifications:
   email: false
-script:
- - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'
+
+# script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("JLD2"); Pkg.test("JLD2"; coverage=true)'
+
 after_success:
   - julia -e 'cd(Pkg.dir("JLD2")); Pkg.add("Coverage"); Pkg.checkout("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
   - nightly
 matrix:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,122 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinaryProvider]]
+deps = ["Compat", "Pkg", "SHA"]
+git-tree-sha1 = "94dac52c662ca793008fb689e3daf626b6139943"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.3.3"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Compat", "Test", "TranscodingStreams"]
+git-tree-sha1 = "82742ef572290f566c6fc6d977d87586a0d3d5f1"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.4.3"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "c478aec93ea90bb99c307a92df17a76131bf275f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.0.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "REPL", "Random", "Serialization", "Test"]
+git-tree-sha1 = "a591110d3ac12c9b4d0cec163fcf234baed7f5ac"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.10.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FileIO]]
+deps = ["InteractiveUtils", "Pkg", "Random", "Test"]
+git-tree-sha1 = "4cfe13dce8564c2d0b96ad4a3a7f99e05fb97d46"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.0.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Compat", "Random", "Test"]
+git-tree-sha1 = "d10e1e4b8fb8c6c50a1458c8e0de8f7abd0fc144"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.5.3"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "JLD2"
+uuid = "30b3fee2-9826-11e8-2ba3-a7612145d6ce"
+authors = ["Simon Kornblith <simonster@users.noreply.github.com>"]
+version = "0.0.7"
+
+[deps]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 DataStructures
 CodecZlib 0.4
 FileIO 0.5.0

--- a/src/bufferedio.jl
+++ b/src/bufferedio.jl
@@ -75,7 +75,7 @@ Base.show(io::IO, ::BufferedReader) = print(io, "BufferedReader")
 
 function readmore!(io::BufferedReader, n::Int)
     f = io.f
-    amount = max(nb_available(f), n)
+    amount = max(bytesavailable(f), n)
     buffer = io.buffer
     oldlen = length(buffer)
     resize!(buffer, oldlen + amount)

--- a/src/data.jl
+++ b/src/data.jl
@@ -761,7 +761,7 @@ function h5convert!(out::Pointers, fls::FixedLengthString, f::JLDFile, x, ::JLDW
     (unsafe_copyto!(convert(Ptr{UInt8}, out), pointer(x), fls.length); nothing)
 end
 h5convert!(out::Pointers, ::Type{Vlen{String}}, f::JLDFile, x, wsession::JLDWriteSession) =
-    store_vlen!(out, UInt8, f, Vector{UInt8}(x), wsession)
+    store_vlen!(out, UInt8, f, unsafe_wrap(Array{UInt8}, pointer(x), ncodeunits(x)), wsession)
 
 jlconvert(::ReadRepresentation{String,Vlen{String}}, f::JLDFile, ptr::Ptr, ::RelOffset) =
     String(jlconvert(ReadRepresentation{UInt8,Vlen{UInt8}}(), f, ptr, NULL_REFERENCE))
@@ -788,8 +788,10 @@ fieldodr(::Type{Symbol}, ::Bool) = Vlen{String}
 h5type(f::JLDFile, ::Type{Symbol}, x) = h5fieldtype(f, Symbol, typeof(x), Val{true})
 odr(::Type{Symbol}) = Vlen{String}
 
-h5convert!(out::Pointers, ::Type{Vlen{String}}, f::JLDFile, x::Symbol, ::JLDWriteSession) =
-    store_vlen!(out, UInt8, f, Vector{UInt8}(String(x)), f.datatype_wsession)
+function h5convert!(out::Pointers, ::Type{Vlen{String}}, f::JLDFile, x::Symbol, ::JLDWriteSession)
+    s = String(x)
+    store_vlen!(out, UInt8, f, unsafe_wrap(Array{UInt8}, pointer(s), ncodeunits(s)), f.datatype_wsession)
+end
 
 constructrr(::JLDFile, ::Type{Symbol}, dt::VariableLengthDatatype{FixedPointDatatype}, ::Vector{ReadAttribute}) =
     dt == H5TYPE_VLEN_UTF8 ? (ReadRepresentation{Symbol,Vlen{String}}(), true) :
@@ -801,9 +803,9 @@ jlconvert(::ReadRepresentation{Symbol,Vlen{String}}, f::JLDFile, ptr::Ptr, ::Rel
 ## BigInts and BigFloats
 
 writeas(::Union{Type{BigInt},Type{BigFloat}}) = String
-wconvert(::Type{String}, x::BigInt) = base(62, x)
+wconvert(::Type{String}, x::BigInt) = string(x, base = 62)
 wconvert(::Type{String}, x::BigFloat) = string(x)
-rconvert(::Type{BigInt}, x::String) = parse(BigInt, x, 62)
+rconvert(::Type{BigInt}, x::String) = parse(BigInt, x, base = 62)
 rconvert(::Type{BigFloat}, x::String) = parse(BigFloat, x)
 
 ## DataTypes
@@ -849,7 +851,7 @@ function typename(T::DataType)
     tn = Symbol[]
     m = T.name.module
     while m != parentmodule(m)
-        push!(tn, module_name(m))
+        push!(tn, nameof(m))
         m = parentmodule(m)
     end
     reverse!(tn)
@@ -858,11 +860,12 @@ function typename(T::DataType)
 end
 
 function h5convert!(out::Pointers, ::DataTypeODR, f::JLDFile, T::DataType, wsession::JLDWriteSession)
-    store_vlen!(out, UInt8, f, Vector{UInt8}(typename(T)), f.datatype_wsession)
+    t = typename(T)
+    store_vlen!(out, UInt8, f, unsafe_wrap(Array{UInt8}, pointer(t), ncodeunits(t)), f.datatype_wsession)
     if isempty(T.parameters)
         h5convert_uninitialized!(out+odr_sizeof(Vlen{UInt8}), Vlen{UInt8})
     else
-        refs = RelOffset[begin
+        refs = RelOffset[
             if isa(x, DataType)
                 # The heuristic here is that, if the field type is a committed data type,
                 # then we commit the datatype and write it as a reference to the committed
@@ -879,7 +882,7 @@ function h5convert!(out::Pointers, ::DataTypeODR, f::JLDFile, T::DataType, wsess
             else
                 write_ref(f, x, wsession)
             end
-        end for x in T.parameters]
+        for x in T.parameters]
         store_vlen!(out+odr_sizeof(Vlen{UInt8}), RelOffset, f, refs, f.datatype_wsession)
     end
     nothing
@@ -1031,7 +1034,7 @@ rconvert(::Type{Core.SimpleVector}, x::Vector{Any}) = Core.svec(x...)
 ## Dicts
 
 writeas(::Type{Dict{K,V}}) where {K,V} = Vector{Pair{K,V}}
-writeas(::Type{ObjectIdDict}) = Vector{Pair{Any,Any}}
+writeas(::Type{IdDict}) = Vector{Pair{Any,Any}}
 wconvert(::Type{Vector{Pair{K,V}}}, x::AbstractDict{K,V}) where {K,V} = collect(x)
 function rconvert(::Type{T}, x::Vector{Pair{K,V}}) where {T<:AbstractDict,K,V}
     d = T()

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -285,7 +285,7 @@ end
 Construct array by reading `ndims` dimensions from `io`. Assumes `io` has already been
 seeked to the correct position.
 """
-function construct_array{T}(io::IO, ::Type{T}, ndims::Int)::Array{T}
+function construct_array(io::IO, ::Type{T}, ndims::Int)::Array{T} where {T}
     if ndims == 1
         n = read(io, Int64)
         Vector{T}(undef, n)

--- a/src/mmapio.jl
+++ b/src/mmapio.jl
@@ -97,7 +97,8 @@ end
 function MmapIO(fname::AbstractString, write::Bool, create::Bool, truncate::Bool)
     truncate && !write && throw(ArgumentError("cannot truncate file that is not writable"))
 
-    f = open(fname, true, write, create, truncate, false)
+    f = open(fname, read = true, write = write,
+             create = create, truncate = truncate, append = false)
     initialsz = truncate ? Int64(0) : filesize(fname)
     @static if Int == Int32
         initialsz > typemax(Int) && error("cannot read a file greater than 2GB on a 32-bit system")

--- a/test/rw.jl
+++ b/test/rw.jl
@@ -37,7 +37,7 @@ AB = Any[A, B]
 t = (3, "cat")
 c = Complex{Float32}(3,7)
 cint = 1+im  # issue 108
-C = reinterpret(Complex{Float64}, B, (4,))
+C = reshape(reinterpret(Complex{Float64}, B), (4,))
 emptyA = zeros(0,2)
 emptyB = zeros(2,0)
 try
@@ -55,7 +55,7 @@ msempty = MyStruct(5, Float64[])
 sym = :TestSymbol
 syms = [:a, :b]
 d = Dict([(syms[1],"aardvark"), (syms[2], "banana")])
-oidd = ObjectIdDict([(syms[1],"aardvark"), (syms[2], "banana")])
+oidd = IdDict([(syms[1],"aardvark"), (syms[2], "banana")])
 ex = quote
     function incrementby1(x::Int)
         x+1
@@ -237,9 +237,9 @@ bitsparamint16  = BitsParams{Int16(1)}()
 tuple_of_tuples = (1, 2, (3, 4, [5, 6]), [7, 8])
 
 # Zero-dimensional arrays
-zerod = Array{Int}()
+zerod = Array{Int}(undef)
 zerod[] = 1
-zerod_any = Array{Any}()
+zerod_any = Array{Any}(undef)
 zerod_any[] = 1.0+1.0im
 
 # Type with None typed field
@@ -313,7 +313,7 @@ macro check(fid, sym)
                 tmp = read($fid, $(string(sym)))
             catch e
                 @show e
-                Base.show_backtrace(STDOUT, catch_backtrace())
+                Base.show_backtrace(stdout, catch_backtrace())
                 error("error reading ", $(string(sym)))
             end
             written_type = typeof($sym)


### PR DESCRIPTION
I gave it a shot but cannot find out why I get the following error:

https://travis-ci.org/gdkrmr/JLD2.jl/jobs/412170446#L501

```
ERROR: LoadError: LoadError: UndefVarError: arr_undef not defined
```
This gets a warning in 0.7:
```
┌ Warning: Deprecated syntax `implicit assignment to global variable `arr_undef``.
│ Use `global arr_undef` instead.
└ @ none:0
```

I removed all the deprecation warning I could locate. I am not sure about about the right usage of `unsafe_wrap` instead of `Vector{UInt8}`, you may want to check those.

I also don't know how to deal with this one:

https://travis-ci.org/gdkrmr/JLD2.jl/jobs/412170446#L495
```
┌ Warning: Deprecated syntax `"begin" inside indexing expression` at /home/travis/build/gdkrmr/JLD2.jl/src/data.jl:900.
└ @ ~/build/gdkrmr/JLD2.jl/src/data.jl:900
```