### PR TITLE
Make uuid match that of JuliaRegistries/General

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "JLD2"
-uuid = "30b3fee2-9826-11e8-2ba3-a7612145d6ce"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 authors = ["Simon Kornblith <simonster@users.noreply.github.com>"]
 version = "0.1.0"
 


### PR DESCRIPTION
This Julia Slack conversation for context:
```
Ed Schmerling [11:41 AM]
are these UUIDs supposed to match? https://github.com/simonster/JLD2.jl/blob/master/Project.toml#L2 and https://github.com/JuliaRegistries/General/blob/master/J/JLD2/Package.toml#L2 (edited)

Fredrik Ekre [11:41 AM]
Yes

Ed Schmerling [11:42 AM]
what is the recommended resolution?

Fredrik Ekre [11:43 AM]
Use the one in the registry
```