### PR TITLE
Patch for proper handling `DataFrame` objects

### DIFF
--- a/test/loadsave.jl
+++ b/test/loadsave.jl
@@ -84,3 +84,18 @@ d = Dict("params/p1" => 1,
          "data" => [[1,2,3], [4.,5.,6]])
 save(fn, d)
 @test load(fn) == d
+
+# Issue #106
+mutable struct MyMutableTest
+    a::Int
+    b::Vector{Int}
+end
+Base.getproperty(df::MyMutableTest, s::Symbol) =
+    throw(ArgumentError("should not be called"))
+Base.setproperty!(df::MyMutableTest, s::Symbol, x::Int) =
+    throw(ArgumentError("should not be called"))
+Base.isequal(x::MyMutableTest, y::MyMutableTest) =
+    isequal(getfield(x, :a), getfield(y, :a)) && isequal(getfield(x, :b), getfield(y, :b))
+mmtd = Dict("A" => MyMutableTest(1, [10]))
+save(fn, mmtd)
+@test isequal(load(fn), mmtd)


### PR DESCRIPTION
This patch changes usage of `setproperty!` to `setfield!` for mutable objects when `odr` is not `nothing`.

This should be considered a quick fix as probably a more consistent redesign of this function would be better, but I do not have access to appropriate test cases.

I have left comments in the code where probably things should be fixed, but I have left them as is for now not to introduce breaking changes I am not sure how to test against.