### PR TITLE
Add soft link and external links in JLD2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,233 +1,296 @@
 ## Unreleased
- - Support for directly reading from and writing to Vector{UInt8}
- - Fix for working with opened IOStream objects
+
+- Support for directly reading from and writing to Vector{UInt8}
+- Fix for working with opened IOStream objects
+- Add support for soft and external links
 
 ## 0.6.3
- - Fix edge case in datatype loading (#692)
- - Add keyword argument constructors to Filters
- - Allow negative compression levels for the ZstdFilter
+
+- Fix edge case in datatype loading (#692)
+- Add keyword argument constructors to Filters
+- Allow negative compression levels for the ZstdFilter
 
 ## 0.6.2
- - Fix an edge case for `Vector{Union{}}`
+
+- Fix an edge case for `Vector{Union{}}`
 
 ## 0.6.1
- - Improved backwards compat for lz4 compression
- - Docs improvements
- - updated compat bounds for filter pkgs
+
+- Improved backwards compat for lz4 compression
+- Docs improvements
+- updated compat bounds for filter pkgs
 
 ## 0.6.0
- - **Breaking**: Rework compression API. Expose filter approach of hdf5 broadly similar to HDF5.jl.
- See docs for description. The basic `compress=true` api still works but backend libraries were
- replaced.
- - Added new filter pkgs `JLD2Lz4` and `JLD2Bzip2` to enable lz4 and bzip2 filters without making
- them dependencies by default.
+
+- **Breaking**: Rework compression API. Expose filter approach of hdf5 broadly similar to HDF5.jl.
+  See docs for description. The basic `compress=true` api still works but backend libraries were
+  replaced.
+- Added new filter pkgs `JLD2Lz4` and `JLD2Bzip2` to enable lz4 and bzip2 filters without making
+  them dependencies by default.
 
 ## 0.5.17
- - update `hash` implementation for internal types to eliminate downstream invalidations
+
+- update `hash` implementation for internal types to eliminate downstream invalidations
 
 ## 0.5.16
- - Improve `readmmap` to work on more types and misaligned data
- - Make default iotype selection dynamic. Makes precompile files relocatable to win7. (#632)
+
+- Improve `readmmap` to work on more types and misaligned data
+- Make default iotype selection dynamic. Makes precompile files relocatable to win7. (#632)
 
 ## 0.5.15
- - Add full control over type mapping by providing a typemap function
+
+- Add full control over type mapping by providing a typemap function
 
 ## 0.5.14
- - Add support for `Memory` and `MemoryRef`
+
+- Add support for `Memory` and `MemoryRef`
 
 ## 0.5.13
- - Make UnPack.jl compat into an extension
- - bumps lower compat for julia to v1.9
+
+- Make UnPack.jl compat into an extension
+- bumps lower compat for julia to v1.9
 
 ## 0.5.12
- - Fix precompile workload for loading on latest julia
+
+- Fix precompile workload for loading on latest julia
 
 ## 0.5.11
- - Make `Upgrade` work for types that sit inside `Union{..}`
+
+- Make `Upgrade` work for types that sit inside `Union{..}`
 
 ## 0.5.10
- - fix regression for `UInt32`
- - **Deprecation**: Do not rely on JLD2 to load a compression library. This feature will be removed in a future release. Instead explicitly add `using` statements into your scripts.
+
+- fix regression for `UInt32`
+- **Deprecation**: Do not rely on JLD2 to load a compression library. This feature will be removed in a future release. Instead explicitly add `using` statements into your scripts.
 
 ## 0.5.9
- - fix regression for `Union{Bool,Nothing}` array elements (#617)
- - fix printing issue in `printtoc`
+
+- fix regression for `Union{Bool,Nothing}` array elements (#617)
+- fix printing issue in `printtoc`
 
 ## 0.5.8
- - Stop using `Base.module_keys` as it is removed on nightly
+
+- Stop using `Base.module_keys` as it is removed on nightly
 
 ## 0.5.7
- - Fix edge case for uninitialized Vlens
+
+- Fix edge case for uninitialized Vlens
 
 ## 0.5.6
- - Add Aqua tests and eliminate method ambiguities
+
+- Add Aqua tests and eliminate method ambiguities
 
 ## 0.5.5
- - Experimental support for writing to and reading from `IO` objects e.g. `jldopen(io, "r")`
+
+- Experimental support for writing to and reading from `IO` objects e.g. `jldopen(io, "r")`
 
 ## 0.5.4
- - Important correctness fix when storing very many equally sized objects
-that may get GC'ed while storing is in progress! (#603)
+
+- Important correctness fix when storing very many equally sized objects
+  that may get GC'ed while storing is in progress! (#603)
 
 ## 0.5.3
- - Bugfix for `<: Function` structs
+
+- Bugfix for `<: Function` structs
 
 ## 0.5.2
- - Remove left-over warning
- - Restrict warning for storing `Function` objects to `anonymous` functions.
+
+- Remove left-over warning
+- Restrict warning for storing `Function` objects to `anonymous` functions.
 
 ## 0.5.1
- - Bugfix and added test for bug introduced in v0.5.0
+
+- Bugfix and added test for bug introduced in v0.5.0
 
 ## 0.5.0
- - Improved encoding of committed datatypes.
- This fixes longstanding issues but new files will not be loaded correctly with JLD2 versions prior to `v0.5.0`.
- Existing files remain readable.
- - JLD2 now warns when storing structures containing `<: Function` objects.
+
+- Improved encoding of committed datatypes.
+  This fixes longstanding issues but new files will not be loaded correctly with JLD2 versions prior to `v0.5.0`.
+  Existing files remain readable.
+- JLD2 now warns when storing structures containing `<: Function` objects.
 
 ## 0.4.53
- - Experimental: Slicing and inplace updating of array datasets
- - updated CI workflows
- - improve pretty printing of attribute header message
- - fix storing of datatype info for h5 compat
+
+- Experimental: Slicing and inplace updating of array datasets
+- updated CI workflows
+- improve pretty printing of attribute header message
+- fix storing of datatype info for h5 compat
 
 ## 0.4.52
- - fix attribute loading
- - new features: `readmmap` `ismmappable`  and `allocate_early` (api experimental)
- - adds Downgrade testing
- - new feature: disable committing datatypes. (restrict to h5 numbers, strings, and arrays)
- - internal cleanup
- - new experimental feature: reconstruct all committed types as `NamedTuple`s
+
+- fix attribute loading
+- new features: `readmmap` `ismmappable` and `allocate_early` (api experimental)
+- adds Downgrade testing
+- new feature: disable committing datatypes. (restrict to h5 numbers, strings, and arrays)
+- internal cleanup
+- new experimental feature: reconstruct all committed types as `NamedTuple`s
 
 ## 0.4.51
- - remove Unicode normalization support due to excessive performance loss
- - rework of header message internals
- - Implement addition and loading of attributes to datasets and groups
- - Add preliminary `Dataset` structure and API
- - cleanup tests
- - remove `Pkg` dependency
- - fix `Upgrade` for Singleton types
+
+- remove Unicode normalization support due to excessive performance loss
+- rework of header message internals
+- Implement addition and loading of attributes to datasets and groups
+- Add preliminary `Dataset` structure and API
+- cleanup tests
+- remove `Pkg` dependency
+- fix `Upgrade` for Singleton types
 
 ## 0.4.50
- - Don't hide exception data during loading and saving (#569)
+
+- Don't hide exception data during loading and saving (#569)
 
 ## 0.4.49
- - update compat bounds
- - add support Zstdcompression
+
+- update compat bounds
+- add support Zstdcompression
 
 ## 0.4.48
- - fix behaviour for unnormalized strings
- - add missing method for load_attributes
- - clean up `using` statements
+
+- fix behaviour for unnormalized strings
+- add missing method for load_attributes
+- clean up `using` statements
 
 ## 0.4.47
- - fix loading structs with more than 256 fields (#558)
+
+- fix loading structs with more than 256 fields (#558)
 
 ## 0.4.46
- - remove usage of `IOBuffer` internals
+
+- remove usage of `IOBuffer` internals
 
 ## 0.4.45
- - fix loading of unknown struct with UnionAll (unknown) type parameter (#538)
+
+- fix loading of unknown struct with UnionAll (unknown) type parameter (#538)
 
 ## 0.4.44
- - fix dispatch around `Union{}` as type parameter
+
+- fix dispatch around `Union{}` as type parameter
 
 ## 0.4.43
- - do not try to `rconvert` `#undef` array elements (#529)
+
+- do not try to `rconvert` `#undef` array elements (#529)
 
 ## 0.4.42
- - improvements in time-to-first save/load on julia v1.10 and up
- - discourage from using custom serialization to `Array` and stop using it internally
- as it cannot properly preserve object identity.
- - fix inline group `show`
- - fix a bug in group loading for the `IOStream` backend
- - reduce invalidations to zero
+
+- improvements in time-to-first save/load on julia v1.10 and up
+- discourage from using custom serialization to `Array` and stop using it internally
+  as it cannot properly preserve object identity.
+- fix inline group `show`
+- fix a bug in group loading for the `IOStream` backend
+- reduce invalidations to zero
 
 ## 0.4.41
- - fix ntuple type with typevar length
- - fix OpaqueData test (HDF5 compat)
+
+- fix ntuple type with typevar length
+- fix OpaqueData test (HDF5 compat)
 
 ## 0.4.40
- - fix unitialized custom-serialized objects
- - allow serializing pkg-modules by name
+
+- fix unitialized custom-serialized objects
+- allow serializing pkg-modules by name
 
 ## 0.4.39
- - backward compatibility support for windows 7 by changing the default IO type to IOStream (#509) (@HongBinYu-hub)
+
+- backward compatibility support for windows 7 by changing the default IO type to IOStream (#509) (@HongBinYu-hub)
 
 ## 0.4.38
- - restrict default Dict encoding to Base implementations
+
+- restrict default Dict encoding to Base implementations
 
 ## 0.4.37
- - Update Dict encoding for latest julia
+
+- Update Dict encoding for latest julia
 
 ## 0.4.36
- - compat bound for TranscodingStreams.jl
+
+- compat bound for TranscodingStreams.jl
 
 ## 0.4.35
- - fix roundtrip of Type{} objects #484
+
+- fix roundtrip of Type{} objects #484
 
 ## 0.4.34
- - reclose file when opening fails
+
+- reclose file when opening fails
 
 ## 0.4.33
- - fix `Upgrade` for parametric types
- - new type reconstruction when matching DataType cannot be found (eval-free)
- - new `parallel_read` keyword for creating stand-alone file handles for multithreaded file reading (@ejmeitz)
+
+- fix `Upgrade` for parametric types
+- new type reconstruction when matching DataType cannot be found (eval-free)
+- new `parallel_read` keyword for creating stand-alone file handles for multithreaded file reading (@ejmeitz)
 
 ## 0.4.32
- - add experimental `JLD2.readas` function for customized reading of custom serialized objects (#468)
+
+- add experimental `JLD2.readas` function for customized reading of custom serialized objects (#468)
 
 ## 0.4.31
- - fix UInt32 truncation error for absurdly large array sizes
- - move test-files to a separate repo
+
+- fix UInt32 truncation error for absurdly large array sizes
+- move test-files to a separate repo
 
 ## 0.4.30
- -  allow loading compressed files during precompilation #446 (@marius311)
+
+- allow loading compressed files during precompilation #446 (@marius311)
 
 ## 0.4.29
- - added `Upgrade` feature
+
+- added `Upgrade` feature
 
 ## 0.4.28
- - compatibility to julia v1.9-dev (@eschnett)
+
+- compatibility to julia v1.9-dev (@eschnett)
 
 ## 0.4.26
- - fix identity relations with custom serialization
+
+- fix identity relations with custom serialization
 
 ## 0.4.25
- - remove leftover debug statement
+
+- remove leftover debug statement
 
 ## 0.4.24
- - read-only support for `JLD.jl` files
- - read-only support for many HDF5 files. Most test files of HDF5.jl are covered
- - read Opaque bit fields
- - read some other string encodings
- - read big endian numbers
- - read typical chunking formats
+
+- read-only support for `JLD.jl` files
+- read-only support for many HDF5 files. Most test files of HDF5.jl are covered
+- read Opaque bit fields
+- read some other string encodings
+- read big endian numbers
+- read typical chunking formats
 
 ## 0.4.23
- - Support for `const` fields in mutable structs
+
+- Support for `const` fields in mutable structs
 
 ## 0.4.22
- - Fix reconstruction of partially initialized structs
+
+- Fix reconstruction of partially initialized structs
 
 ## 0.4.21
- - Add explicit type mapping
+
+- Add explicit type mapping
 
 ## 0.4.20
- - TTFX improvements
- - Add a comment on jldsave (@BoundaryValueProblems)
+
+- TTFX improvements
+- Add a comment on jldsave (@BoundaryValueProblems)
+
 ## 0.4.19
- - Don't inline long ntuples
+
+- Don't inline long ntuples
 
 ## 0.4.18
- - Bugfix for dynamic loading of CodecZlib
+
+- Bugfix for dynamic loading of CodecZlib
 
 ## 0.4.17
- - Automatically transform symbol keys in strings with a warning (@theogf)
+
+- Automatically transform symbol keys in strings with a warning (@theogf)
 
 ## 0.4.16
- - Fix @save macro
- - Improve auto-conversion of convertible types
+
+- Fix @save macro
+- Improve auto-conversion of convertible types
 
 ## 0.4.15
- - Implement `Base.keytype` for `JLDFile` and `Group`
+
+- Implement `Base.keytype` for `JLDFile` and `Group`

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
         "Internals & Design" => "internals.md",
         "HDF5 Compatibility" => "hdf5compat.md",
         "Advanced Usage" => "advanced.md",
+        "Dataset Links" => "external_links.md",
         "Legacy" => "legacy.md",
         "Troubleshooting" => "troubleshooting.md"
     ],

--- a/docs/src/external_links.md
+++ b/docs/src/external_links.md
@@ -1,0 +1,31 @@
+# Links in JLD2
+
+JLD2 supports three types of links compatible with the HDF5 specification:
+
+- **Hard Links** (default): Direct pointers to objects within the same file
+- **Soft Links**: Path-based symbolic links resolved at access time
+- **External Links**: References to objects in different files
+
+## Usage
+
+```@example
+using JLD2
+jldopen("file.jld2", "w") do f
+    f["data"] = [1, 2, 3, 4, 5]
+
+    # Soft link (within same file)
+    f["data_alias"] = JLD2.Link("/data")
+
+    # External link (to different file)
+    f["remote_data"] = JLD2.Link("/dataset"; file="other.jld2")
+end
+
+# Create external file (before or after)
+jldsave("other.jld2"; dataset="external data")
+
+# Access links transparently
+jldopen("file.jld2", "r") do f
+    f["data_alias"]   # Returns [1, 2, 3, 4, 5]
+    f["remote_data"]  # Loads from other.jld2
+end
+```

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -265,8 +265,7 @@ function initialize_fileobject!(f::JLDFile)
     end
     f.root_group = load_group(f, f.root_group_offset)
 
-    # Use lookup_link directly instead of lookup_offset
-    types_offset = getoffset(f.root_group, lookup_link(f.root_group, "_types"))
+    types_offset = getoffset(f.root_group, lookup_link(f.root_group, "_types"), erroroninvalid=false)
     if types_offset !== UNDEFINED_ADDRESS
         f.types_group = f.loaded_groups[types_offset] = load_group(f, types_offset)
         for (i, link) in enumerate(values(f.types_group.written_links))

--- a/src/JLD2.jl
+++ b/src/JLD2.jl
@@ -413,8 +413,6 @@ Base.keys(f::JLDFile) = filter!(x->x != "_types", keys(f.root_group))
 Base.keytype(f::JLDFile) = String
 Base.length(f::Union{JLDFile, Group}) = length(keys(f))
 
-lookup_link(f::JLDFile, name::AbstractString) = lookup_link(f.root_group, name)
-
 Base.get(default::Function, f::Union{JLDFile, Group}, name::AbstractString) =
     haskey(f, name) ? f[name] : default()
 Base.get(f::Union{JLDFile, Group}, name::AbstractString, default) =

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -362,21 +362,8 @@ end
 
 # Links
 message_size(msg::Pair{String, RelOffset}) = jlsizeof(Val(HmLinkMessage); link_name=msg.first)
-message_size(msg::Pair{String, Link}) = message_size_for_link(msg.first, msg.second)
-
-write_header_message(io, f, msg::Pair{String, RelOffset}, _=nothing) =
-    write_header_message(io, Val(HmLinkMessage); link_name=msg.first, target=msg.second)
-write_header_message(io, f, msg::Pair{String, Link}, _=nothing) =
-    write_link_message(io, msg.first, msg.second)
-
-"""
-    message_size_for_link(name::String, link::Link) -> Int
-
-Calculate the size of a link message for the given link type.
-"""
-function message_size_for_link(link_name::String, link::Link)
+function message_size((link_name, link)::Pair{String, Link})
     is_hard_link(link) && return jlsizeof(Val(HmLinkMessage); link_name)
-
     flags = UInt8(0x10 | 0x08 | size_flag(sizeof(link_name)))
     if is_soft_link(link)
         jlsizeof(Val(HmLinkMessage); link_name, flags, link_type=UInt8(1),
@@ -387,6 +374,11 @@ function message_size_for_link(link_name::String, link::Link)
                  external_link=UInt8[])
     end
 end
+
+write_header_message(io, f, msg::Pair{String, RelOffset}, _=nothing) =
+    write_header_message(io, Val(HmLinkMessage); link_name=msg.first, target=msg.second)
+write_header_message(io, f, msg::Pair{String, Link}, _=nothing) =
+    write_link_message(io, msg.first, msg.second)
 
 """
     write_link_message(io, name::String, link::Link)

--- a/src/explicit_datasets.jl
+++ b/src/explicit_datasets.jl
@@ -315,15 +315,15 @@ function get_dataset(g::Group, name::String)
     f.n_times_opened == 0 && throw(ArgumentError("file is closed"))
 
     (g, name) = pathize(g, name, false)
-    roffset = lookup_offset(g, name)
-    if roffset == UNDEFINED_ADDRESS
-        if isempty(name)
-            # this is a group
-            return get_dataset(f, group_offset(g), g, name)
-        end
-        throw(KeyError(name))
+
+    if isempty(name)
+        # this is a group
+        return get_dataset(f, group_offset(g), g, name)
     end
-    get_dataset(f, roffset, g, name)
+
+    link = lookup_link(g, name)
+    offset = getoffset(g, link)
+    return get_dataset(f, offset, g, name)
 end
 
 function get_dataset(f::JLDFile, offset::RelOffset, g=f.root_group, name="")
@@ -362,8 +362,53 @@ end
 
 # Links
 message_size(msg::Pair{String, RelOffset}) = jlsizeof(Val(HmLinkMessage); link_name=msg.first)
+message_size(msg::Pair{String, Link}) = message_size_for_link(msg.first, msg.second)
+
 write_header_message(io, f, msg::Pair{String, RelOffset}, _=nothing) =
     write_header_message(io, Val(HmLinkMessage); link_name=msg.first, target=msg.second)
+write_header_message(io, f, msg::Pair{String, Link}, _=nothing) =
+    write_link_message(io, msg.first, msg.second)
+
+"""
+    message_size_for_link(name::String, link::Link) -> Int
+
+Calculate the size of a link message for the given link type.
+"""
+function message_size_for_link(link_name::String, link::Link)
+    is_hard_link(link) && return jlsizeof(Val(HmLinkMessage); link_name)
+
+    flags = UInt8(0x10 | 0x08 | size_flag(sizeof(link_name)))
+    if is_soft_link(link)
+        jlsizeof(Val(HmLinkMessage); link_name, flags, link_type=UInt8(1),
+                 link_info_size=sizeof(link.path), soft_link=UInt8[])
+    else  # external link
+        jlsizeof(Val(HmLinkMessage); link_name, flags, link_type=UInt8(64),
+                 link_info_size=3+sizeof(link.external_file)+sizeof(link.path),
+                 external_link=UInt8[])
+    end
+end
+
+"""
+    write_link_message(io, name::String, link::Link)
+
+Write a link message for the given link type to the I/O stream.
+"""
+function write_link_message(io, link_name::String, link::Link)
+    if is_hard_link(link)
+        return write_header_message(io, Val(HmLinkMessage); link_name, target=link.offset)
+    end
+    flags = UInt8(0x10 | 0x08 | size_flag(sizeof(link_name)))
+    if is_soft_link(link)
+        soft_link = Vector{UInt8}(link.path)
+        write_header_message(io, Val(HmLinkMessage); link_name, flags, link_type=1, soft_link)
+    elseif is_external_link(link)
+        # External link data: two null-terminated strings
+        external_link = vcat(0x00, Vector{UInt8}(link.external_file), 0x00,
+                            Vector{UInt8}(link.path), 0x00)
+        write_header_message(io, Val(HmLinkMessage); link_name, flags, link_type=64,
+                           external_link)
+    end
+end
 
 function attach_message(f::JLDFile, offset, messages, wsession=JLDWriteSession();
     chunk_start,

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -16,19 +16,50 @@ Construct a group named `name` as a child of group `g`.
 """
 Group(g::Group{T}, name::AbstractString; kwargs...) where {T} = (g[name] = Group{T}(g.f; kwargs...))
 
-"""
-    lookup_offset(g::Group, name::AbstractString) -> RelOffset
 
-Lookup the offset of a dataset in a group. Returns `UNDEFINED_ADDRESS` if the dataset is
-not present. Does not inspect `unwritten_child_groups`.
 """
-function lookup_offset(g::Group, name::AbstractString)
+    lookup_link(g::Group, name::AbstractString) -> Union{Link, Nothing}
+
+Lookup a link in a group by name. Returns the Link object if found, or `nothing`
+if not present. Supports all link types (hard, soft, external).
+"""
+function lookup_link(g::Group, name::AbstractString)
     if g.last_chunk_start_offset != -1
         # Has been saved to file, so written_links exists
-        roffset = get(g.written_links, name, UNDEFINED_ADDRESS)
-        roffset != UNDEFINED_ADDRESS && return roffset
+        link = get(g.written_links, name, nothing)
+        link !== nothing && return link
     end
-    roffset = get(g.unwritten_links, name, UNDEFINED_ADDRESS)
+    return get(g.unwritten_links, name, Link())
+end
+
+
+"""
+    getoffset(group::Group, link::Link; erroroninvalid::Bool=true) -> RelOffset
+
+Get the offset for a link by resolving it if necessary.
+
+- **Hard links**: Returns `link.offset` directly (may be UNDEFINED_ADDRESS)
+- **Soft links**: Recursively resolves the soft link path and returns the target offset
+- **External links**: Errors if `erroroninvalid=true`, otherwise returns UNDEFINED_ADDRESS
+
+This centralizes link resolution logic and simplifies calling code.
+"""
+function getoffset(g::Group, link::Link; erroroninvalid::Bool=true)
+    if is_hard_link(link)
+        return link.offset
+    elseif is_soft_link(link)
+        # Recursively resolve soft link
+        target_link = lookup_link(g, link.path)
+        if !is_set(target_link)
+            erroroninvalid && throw(ArgumentError("Soft link target not found: $(link.path)"))
+            return UNDEFINED_ADDRESS
+        end
+        # Recursively resolve in case target is also a soft link
+        return getoffset(g, target_link; erroroninvalid)
+    else  # external link
+        erroroninvalid && throw(ArgumentError("Cannot get offset for external link to $(link.external_file):$(link.path)"))
+        return UNDEFINED_ADDRESS
+    end
 end
 
 """
@@ -51,26 +82,33 @@ function pathize(g::Group, name::AbstractString, create::Bool)
                 continue
             end
             # See if a group already exists
-            offset = lookup_offset(g, dir)
-            if offset == UNDEFINED_ADDRESS
-                if haskey(g.unwritten_child_groups, dir)
-                    # It's possible that lookup_offset fails because the group has not yet
-                    # been written to the file
-                    g = g.unwritten_child_groups[dir]
-                elseif create
-                    # No group exists, so create a new group
-                    newg = G(f)
-                    g.unwritten_child_groups[dir] = newg
-                    g = newg
-                else
-                    throw(KeyError(join(dirs[1:i], '/')))
-                end
-            elseif haskey(f.loaded_groups, offset)
-                g = f.loaded_groups[offset]::G
-            elseif !isgroup(f, offset)
-                throw(ArgumentError("path $(join(dirs[1:i], '/')) points to a dataset, not a group"))
+            # Check unwritten_child_groups first
+            if haskey(g.unwritten_child_groups, dir)
+                g = g.unwritten_child_groups[dir]
             else
-                g = f.loaded_groups[offset] = load_group(f, offset)::G
+                link = lookup_link(g, dir)
+                if !is_set(link)
+                    if create
+                        # No group exists, so create a new group
+                        newg = G(f)
+                        g.unwritten_child_groups[dir] = newg
+                        g = newg
+                    else
+                        throw(KeyError(join(dirs[1:i], '/')))
+                    end
+                elseif is_hard_link(link)
+                    offset = link.offset
+                    if haskey(f.loaded_groups, offset)
+                        g = f.loaded_groups[offset]::G
+                    elseif !isgroup(f, offset)
+                        throw(ArgumentError("path $(join(dirs[1:i], '/')) points to a dataset, not a group"))
+                    else
+                        g = f.loaded_groups[offset] = load_group(f, offset)::G
+                    end
+                else
+                    # Non-hard links (soft/external) cannot be used for group navigation in pathize
+                    throw(ArgumentError("path $(join(dirs[1:i], '/')) contains a link that cannot be used for group navigation"))
+                end
             end
         end
 
@@ -84,19 +122,27 @@ function pathize(g::Group, name::AbstractString, create::Bool)
     return (g::G, name)
 end
 
-function Base.getindex(g::Group, name::AbstractString)
+@nospecializeinfer function Base.getindex(g::Group, name::AbstractString)
     f = g.f
     f.n_times_opened == 0 && throw(ArgumentError("file is closed"))
 
     (g, name) = pathize(g, name, false)
     isempty(name) && return g
-    roffset = lookup_offset(g, name)
-    if roffset == UNDEFINED_ADDRESS
-        haskey(g.unwritten_child_groups, name) && return g.unwritten_child_groups[name]
-        throw(KeyError(name))
-    end
 
-    Base.inferencebarrier(load_dataset(f, roffset))
+    # Check for unwritten child groups first
+    haskey(g.unwritten_child_groups, name) && return g.unwritten_child_groups[name]
+
+    link = lookup_link(g, name)
+    !is_set(link) && throw(KeyError(name))
+
+    if is_hard_link(link)
+        return Base.inferencebarrier(load_dataset(f, link.offset))
+    elseif is_external_link(link)
+        return load_external_dataset(g.f, link)
+    else  # soft link
+        haskey(g, link.path) || throw(ArgumentError("Soft link target not found: $(link.path)"))
+        return g[link.path]
+    end
 end
 
 @nospecializeinfer function Base.write(
@@ -141,9 +187,19 @@ function Base.setindex!(g::Group, offset::RelOffset, name::AbstractString)
     if g.last_chunk_start_offset != -1 && g.continuation_message_goes_here == -1
         error("objects cannot be added to this group because it was created with a previous version of JLD2")
     end
-    g.unwritten_links[name] = offset
+    g.unwritten_links[name] = Link(offset)
     g
 end
+
+# New method to accept Link directly
+function Base.setindex!(g::Group, link::Link, name::AbstractString)
+    if g.last_chunk_start_offset != -1 && g.continuation_message_goes_here == -1
+        error("objects cannot be added to this group because it was created with a previous version of JLD2")
+    end
+    g.unwritten_links[name] = link
+    g
+end
+
 
 function Base.haskey(g::Group, name::AbstractString)
     G = typeof(g)
@@ -160,21 +216,20 @@ function Base.haskey(g::Group, name::AbstractString)
             end
 
             # See if a group already exists
-            offset = lookup_offset(g, dir)
-            if offset == UNDEFINED_ADDRESS
-                if haskey(g.unwritten_child_groups, dir)
-                    # It's possible that lookup_offset fails because the group has not yet
-                    # been written to the file
-                    g = g.unwritten_child_groups[dir]::G
-                else
-                    return false
-                end
-            elseif haskey(f.loaded_groups, offset)
-                g = f.loaded_groups[offset]::G
-            elseif !isgroup(f, offset)
-                return false
+            # Check unwritten_child_groups first
+            if haskey(g.unwritten_child_groups, dir)
+                g = g.unwritten_child_groups[dir]::G
             else
-                g = f.loaded_groups[offset] = load_group(f, offset)::G
+                link = lookup_link(g, dir)
+                offset = getoffset(g, link; erroroninvalid=false)
+                offset == UNDEFINED_ADDRESS && return false
+                if haskey(f.loaded_groups, offset)
+                    g = f.loaded_groups[offset]::G
+                elseif !isgroup(f, offset)
+                    return false
+                else
+                    g = f.loaded_groups[offset] = load_group(f, offset)::G
+                end
             end
         end
 
@@ -200,9 +255,40 @@ end
 
 Base.keytype(::Group) = String
 
+"""
+    parse_link_message(wmsg::HmWrap{HmLinkMessage}) -> Link
+
+Parse a link message from the HDF5 format and return the appropriate Link.
+Handles hard links (type 0), soft links (type 1), and external links (type 64).
+"""
+function parse_link_message(wmsg::HmWrap{HmLinkMessage})::Link
+    if isset(wmsg.flags, 3)
+        link_type = wmsg.link_type
+        if link_type == 0  # Hard link
+            wmsg.target == UNDEFINED_ADDRESS &&
+                throw(InvalidDataException("Hard link has UNDEFINED_ADDRESS target"))
+            return Link(wmsg.target)
+        elseif link_type == 1  # Soft link
+            return Link(UNDEFINED_ADDRESS, String(wmsg.soft_link), "")
+        elseif link_type == 64  # External link
+            strings = split(String(wmsg.external_link), '\0', keepempty=false)
+            length(strings) == 2 ||
+                throw(InvalidDataException("External link must have two null-terminated strings"))
+            return Link(UNDEFINED_ADDRESS, String(strings[2]), String(strings[1]))
+        else
+            throw(UnsupportedFeatureException("Unsupported link type: $link_type"))
+        end
+    else
+        # Default to hard link when type flag not set
+        wmsg.target != UNDEFINED_ADDRESS ||
+            throw(InvalidDataException("Link has no type and UNDEFINED_ADDRESS target"))
+        return Link(wmsg.target)
+    end
+end
+
 function load_group(f::JLDFile, offset::RelOffset)
     # Messages
-    links = OrderedDict{String,RelOffset}()
+    links = OrderedDict{String,Link}()
 
     next_link_offset::Int64 = -1
     link_phase_change_max_compact::Int64 = -1
@@ -244,7 +330,7 @@ function load_group(f::JLDFile, offset::RelOffset)
             end
         elseif msg.type == HmLinkMessage
             wmsg = HmWrap(HmLinkMessage, msg)
-            links[wmsg.link_name] = wmsg.target
+            links[wmsg.link_name] = parse_link_message(wmsg)
         elseif msg.type == HmSymbolTable
             wmsg = HmWrap(HmSymbolTable, msg)
             v1btree_address = wmsg.v1btree_address
@@ -255,14 +341,14 @@ function load_group(f::JLDFile, offset::RelOffset)
     if fractal_heap_address != UNDEFINED_ADDRESS
         records = read_btree(f, fractal_heap_address, name_index_btree)::Vector{Tuple{String, RelOffset}}
         for r in records
-            links[r[1]] = r[2]
+            links[r[1]] = Link(r[2])
         end
     end
 
     if v1btree_address != UNDEFINED_ADDRESS
         records = read_oldstyle_group(f, v1btree_address, name_index_heap)::Vector{Tuple{String, RelOffset}}
         for r in records
-            links[r[1]] = r[2]
+            links[r[1]] = Link(r[2])
         end
     end
 
@@ -272,19 +358,19 @@ function load_group(f::JLDFile, offset::RelOffset)
 
     Group{typeof(f)}(f, chunk_start, continuation_msg_address, chunk_end, next_link_offset,
                      est_num_entries, est_link_name_len,
-                     OrderedDict{String,RelOffset}(), OrderedDict{String,Group}(), links)
+                     OrderedDict{String,Link}(), OrderedDict{String,Group}(), links)
 end
 
 """
     links_size(pairs)
 
 Returns the size of several link messages. `pairs` is an iterator of
-`String => RelOffset` pairs.
+`String => AbstractLink` pairs.
 """
 function links_size(pairs)
     sz = 0
-    for (name::String,) in pairs
-        sz += jlsizeof(Val(HmLinkMessage); link_name=name)
+    for (name::String, link) in pairs
+        sz += message_size_for_link(name, link)
     end
     sz
 end
@@ -309,7 +395,7 @@ function save_group(g::Group)
     if !isempty(g.unwritten_child_groups)
         for (name, child_group) in g.unwritten_child_groups
             retval = save_group(child_group)
-            g.unwritten_links[name] = retval
+            g.unwritten_links[name] = Link(retval)
         end
         empty!(g.unwritten_child_groups)
     end
@@ -347,6 +433,11 @@ function save_group(g::Group)
         chunk_start = g.last_chunk_start_offset,
         chunk_end = g.last_chunk_checksum_offset,
         next_msg_offset)
+
+    # Transfer unwritten links to written links after successful write
+    merge!(g.written_links, g.unwritten_links)
+    empty!(g.unwritten_links)
+
     # this is clearly suboptimal
     # TODO: this should always return the object start
     # but for "continued" versions this is not the case
@@ -391,12 +482,30 @@ function show_group(io::IO, g::Group, maxnumlines::Int=10, prefix::String=" ", s
     for i = 1:length(ks)
         k = ks[i]
         islast = i == length(ks)
-        isagroup = haskey(g.unwritten_child_groups, k) || isgroup(g.f, lookup_offset(g, k))
+        # Check if this is a group
+        link = lookup_link(g, k)
+        if haskey(g.unwritten_child_groups, k)
+            isagroup = true
+        else
+            # Try to get the offset; for external links or unresolvable soft links, treat as non-group
+            offset = getoffset(g, link; erroroninvalid=false)
+            isagroup = (offset != UNDEFINED_ADDRESS) && isgroup(g.f, offset)
+        end
         if (maxnumlines <= 1 && !islast) #|| (maxnumlines < 2 && isagroup))
             print(io, prefix, "└─ ⋯ ($(length(ks)-i+1) more entries)")
             return 0
         end
-        print(io, prefix, islast ? "└─" : "├─", isagroup ? "📂 " : "🔢 ", k)
+        # Choose appropriate icon based on link type and whether it's a group
+        icon = if isagroup
+            "📂 "  # folder for groups
+        elseif is_external_link(link)
+            "🔗 "  # link icon for external links
+        elseif is_soft_link(link)
+            "↗️ "   # arrow for soft links
+        else
+            "🔢 "  # default for hard link datasets
+        end
+        print(io, prefix, islast ? "└─" : "├─", icon, k)
         maxnumlines = maxnumlines - 1
         if isagroup
             newg = g[k]

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -341,20 +341,6 @@ function load_group(f::JLDFile, offset::RelOffset)
                      OrderedDict{String,Link}(), OrderedDict{String,Group}(), links)
 end
 
-"""
-    links_size(pairs)
-
-Returns the size of several link messages. `pairs` is an iterator of
-`String => AbstractLink` pairs.
-"""
-function links_size(pairs)
-    sz = 0
-    for (name::String, link) in pairs
-        sz += message_size_for_link(name, link)
-    end
-    sz
-end
-
 function group_extra_space(g)
     remaining_entries = g.est_num_entries - length(g.unwritten_links)
     extraspace = remaining_entries * (12 + g.est_link_name_len + 4)
@@ -389,7 +375,7 @@ function save_group(g::Group)
         totalsize = jlsizeof(Val(HmLinkInfo))
         totalsize += jlsizeof(Val(HmGroupInfo); g.est_num_entries, g.est_link_name_len)
         totalsize += CONTINUATION_MSG_SIZE
-        totalsize += links_size(g.unwritten_links)
+        totalsize += sum(message_size, g.unwritten_links, init=0)
         # add to size to make space for additional links
         totalsize += group_extra_space(g)
 

--- a/src/headermessages.jl
+++ b/src/headermessages.jl
@@ -70,11 +70,11 @@ end
     link_name::@FixedLengthString(link_name_len) # non-null-terminated
     (!isset(flags, 3) || link_type==0) && (target::RelOffset = UNDEFINED_ADDRESS)
     if isset(flags, 3) && link_type == 1
-        link_info_size::UInt16
+        link_info_size::UInt16 = length(kw.soft_link)
         soft_link::@Blob(link_info_size) # non-null terminated string
     end
     if isset(flags, 3) && link_type == 64
-        link_info_size::UInt16
+        link_info_size::UInt16 = length(kw.external_link)
         external_link::@Blob(link_info_size) # two null-terminated strings
     end
 end

--- a/src/links.jl
+++ b/src/links.jl
@@ -1,0 +1,106 @@
+"""
+    Link
+
+Unified link type representing hard links, soft links, and external links.
+Uses a discriminated union approach for type stability.
+
+# Link types (determined by field values):
+- Hard link: `path` and `external_file` empty (offset may be UNDEFINED_ADDRESS for uninitialized)
+- Soft link: `path` non-empty, `external_file` empty
+- External link: `external_file` non-empty
+"""
+struct Link
+    offset::RelOffset    # Hard link target (may be UNDEFINED_ADDRESS for uninitialized hard links)
+    path::String         # Object path within file (for soft/external links)
+    external_file::String # External file path (empty for hard/soft links)
+
+    # Inner constructor - allows all combinations including uninitialized hard links
+    function Link(offset::RelOffset, path::String, external_file::String)
+        new(offset, path, external_file)
+    end
+end
+
+# User-facing constructor with keyword argument for external links
+"""
+    Link(path::String; file::Union{String,Nothing}=nothing) -> Link
+
+Create a soft link or external link to an object.
+
+# Arguments
+- `path`: Path to the target object
+- `file`: (Optional) External file path. If provided, creates an external link to `path` in `file`.
+          If omitted, creates a soft link to `path` in the current file.
+
+# Examples
+```julia
+# Soft link (within same file)
+g["alias"] = JLD2.Link("/path/to/data")
+
+# External link (to another file)
+g["external"] = JLD2.Link("/path/to/data"; file="/path/to/external/file.jld2")
+```
+"""
+function Link(path::String; file::Union{AbstractString,Nothing}=nothing)
+    isempty(path) && throw(ArgumentError("Link path cannot be empty"))
+    if isnothing(file)
+        Link(UNDEFINED_ADDRESS, path, "")  # Soft link
+    else
+        isempty(file) && throw(ArgumentError("External file path cannot be empty"))
+        Link(UNDEFINED_ADDRESS, replace(path, '\\' => '/'), String(file))  # External link
+    end
+end
+
+# Internal constructor for hard links (used by JLD2 internals, not exported)
+Link(offset::RelOffset) = Link(offset, "", "")
+Link() = Link(UNDEFINED_ADDRESS, "", "")
+
+# Type predicates (zero-cost field checks)
+# Note: Hard links are identified by having empty path and external_file fields
+# The offset may be UNDEFINED_ADDRESS for uninitialized hard links
+is_hard_link(link::Link) = isempty(link.path) && isempty(link.external_file)
+is_external_link(link::Link) = !isempty(link.external_file)
+is_soft_link(link::Link) = !isempty(link.path) && isempty(link.external_file)
+is_set(link::Link) = (link.offset != UNDEFINED_ADDRESS) || !isempty(link.path)
+
+# Display methods
+function Base.show(io::IO, link::Link)
+    if is_hard_link(link)
+        if link.offset == UNDEFINED_ADDRESS
+            print(io, "Link(hard: uninitialized)")
+        else
+            print(io, "Link(hard: ", link.offset, ")")
+        end
+    elseif is_soft_link(link)
+        print(io, "Link(soft: \"", link.path, "\")")
+    else
+        print(io, "Link(external: \"", link.external_file, "\", \"", link.path, "\")")
+    end
+end
+
+# Equality and hashing
+Base.:(==)(a::Link, b::Link) =
+    a.offset == b.offset && a.path == b.path && a.external_file == b.external_file
+
+Base.hash(link::Link, h::UInt) = hash((link.offset, link.path, link.external_file), h)
+
+"""
+    load_external_dataset(current_file::JLDFile, link::Link)
+
+Load a dataset from an external file referenced by an external link.
+"""
+function load_external_dataset(current_file, link::Link)
+    external_file = normpath(joinpath(dirname(current_file.path), link.external_file))
+    isfile(external_file) || throw(ArgumentError("External file not found: $external_file"))
+
+    # Check if file is already open
+    lock(OPEN_FILES_LOCK) do
+        if external_file in keys(OPEN_FILES)
+            existing_file = OPEN_FILES[external_file].value
+            !isnothing(existing_file) && return existing_file[link.path]
+        end
+    end
+
+    jldopen(external_file, "r") do f
+        f[link.path]
+    end
+end

--- a/src/loadsave.jl
+++ b/src/loadsave.jl
@@ -140,7 +140,10 @@ macro load(filename, vars...)
         f = jldopen(filename)
         try
             for n in keys(f)
-                if !isgroup(f, lookup_offset(f.root_group, n))
+                # Eagerly resolve links to determine if this is a group
+                # When using @load, users want all data loaded, including through soft/external links
+                val = f[n]
+                if !isa(val, Group)
                     push!(vars, Symbol(n))
                 end
             end

--- a/src/object_headers.jl
+++ b/src/object_headers.jl
@@ -80,13 +80,13 @@ print_header_messages(f::JLDFile, name::AbstractString) =
 function print_header_messages(g::Group, name::AbstractString)
     g.f.n_times_opened == 0 && throw(ArgumentError("file is closed"))
     (g, name) = pathize(g, name, false)
-    roffset = lookup_offset(g, name)
-    if roffset == UNDEFINED_ADDRESS
-        if isempty(name)
-            roffset = g.f.root_group_offset
-        else
-            throw(ArgumentError("did not find a group or dataset named \"$name\""))
-        end
+
+    if isempty(name)
+        # This is the group itself
+        roffset = g.f.root_group_offset
+    else
+        link = lookup_link(g, name)
+        roffset = getoffset(g, link; erroroninvalid=true)
     end
     return print_header_messages(g.f, roffset)
 end

--- a/test/links.jl
+++ b/test/links.jl
@@ -1,0 +1,171 @@
+using JLD2, Test
+
+@testset "Link Types" begin
+    @testset "Link Type" begin
+        # Test hard link (internal constructor)
+        offset = JLD2.RelOffset(UInt64(1000))
+        hard_link = JLD2.Link(offset)
+        @test hard_link.offset == offset
+        @test JLD2.is_hard_link(hard_link)
+
+        # Test soft link
+        soft_link = JLD2.Link("/path/to/dataset")
+        @test soft_link.path == "/path/to/dataset"
+        @test JLD2.is_soft_link(soft_link)
+
+        # Test soft link validation
+        @test_throws ArgumentError JLD2.Link("")
+        relative_link = JLD2.Link("../relative/path")
+        @test relative_link.path == "../relative/path"
+
+        # Test external link
+        external_link = JLD2.Link("/dataset"; file="external_file.h5")
+        @test external_link.external_file == "external_file.h5"
+        @test external_link.path == "/dataset"
+        @test JLD2.is_external_link(external_link)
+
+        # Test external link validation
+        @test_throws ArgumentError JLD2.Link("/dataset"; file="")
+        # Path traversal is allowed
+        external_with_dotdot = JLD2.Link("/dataset"; file="../path/file.h5")
+        @test external_with_dotdot.external_file == "../path/file.h5"
+    end
+
+    @testset "Link Equality and Hashing" begin
+        offset1 = JLD2.RelOffset(UInt64(1000))
+        offset2 = JLD2.RelOffset(UInt64(2000))
+
+        # Hard link equality
+        hard1 = JLD2.Link(offset1)
+        hard2 = JLD2.Link(offset1)
+        hard3 = JLD2.Link(offset2)
+        @test hard1 == hard2
+        @test hard1 != hard3
+        @test hash(hard1) == hash(hard2)
+        @test hash(hard1) != hash(hard3)
+
+        # Soft link equality
+        soft1 = JLD2.Link("/path1")
+        soft2 = JLD2.Link("/path1")
+        soft3 = JLD2.Link("/path2")
+        @test soft1 == soft2
+        @test soft1 != soft3
+        @test hash(soft1) == hash(soft2)
+        @test hash(soft1) != hash(soft3)
+
+        # External link equality
+        ext1 = JLD2.Link("/dataset1"; file="file1.h5")
+        ext2 = JLD2.Link("/dataset1"; file="file1.h5")
+        ext3 = JLD2.Link("/dataset1"; file="file2.h5")
+        ext4 = JLD2.Link("/dataset2"; file="file1.h5")
+        @test ext1 == ext2
+        @test ext1 != ext3
+        @test ext1 != ext4
+        @test hash(ext1) == hash(ext2)
+        @test hash(ext1) != hash(ext3)
+        @test hash(ext1) != hash(ext4)
+
+        # Cross-type inequality
+        @test hard1 != soft1
+        @test hard1 != ext1
+        @test soft1 != ext1
+    end
+
+    @testset "Display Methods" begin
+        offset = JLD2.RelOffset(UInt64(1000))
+        hard_link = JLD2.Link(offset)
+        soft_link = JLD2.Link("/path/to/dataset")
+        external_link = JLD2.Link("/dataset"; file="external.h5")
+
+        # Test that show methods don't throw
+        @test sprint(show, hard_link) isa String
+        @test sprint(show, soft_link) isa String
+        @test sprint(show, external_link) isa String
+
+        # Test basic formatting
+        @test occursin("hard", sprint(show, hard_link))
+        @test occursin("soft", sprint(show, soft_link))
+        @test occursin("external", sprint(show, external_link))
+        @test occursin("/path/to/dataset", sprint(show, soft_link))
+        @test occursin("external.h5", sprint(show, external_link))
+    end
+end
+
+@testset "Phase 2: External Link Creation API" begin
+
+    jldopen("test_external.jld2", "w") do f
+        f["dataset1"] = [1, 2, 3, 4, 5]
+        f["dataset2"] = "Hello from external file!"
+        f["nested/data"] = Dict("key1" => 100, "key2" => 200)
+    end
+
+    jldopen("test_main.jld2", "w") do f
+        # Test external link creation
+        f["external_data"] = JLD2.Link("/dataset1"; file="test_external.jld2")
+        f["external_string"] = JLD2.Link("/dataset2"; file="test_external.jld2")
+        f["external_nested"] = JLD2.Link("/nested/data"; file="test_external.jld2")
+
+        # Test direct Link assignment
+        external_link = JLD2.Link("/dataset1"; file="test_external.jld2")
+        f["direct_external"] = external_link
+
+        # Test soft link creation
+        f["original_data"] = [10, 20, 30]
+        f["soft_link_to_data"] = JLD2.Link("/original_data")
+    end
+
+    # Clean up test files
+    for file in ["test_main.jld2", "test_external.jld2"]
+        isfile(file) && rm(file)
+    end
+end
+
+using JLD2: UnsupportedFeatureException
+
+@testset "Soft Link Support" begin
+
+    @testset "Enhanced Soft Link Path Resolution" begin
+        # Test soft link resolution with current Phase 5 capabilities
+        mktempdir() do dir
+            test_file = joinpath(dir, "soft_link_resolution_test.jld2")
+
+            jldopen(test_file, "w") do f
+                # Create hierarchical structure
+                data_group = JLD2.Group(f, "data")
+                measurements_group = JLD2.Group(data_group, "measurements")
+                f["data/measurements/temperature"] = [20.5, 21.0, 19.8, 22.1]
+                data_group["abs_link_to_temp"] = JLD2.Link("/data/measurements/temperature")
+                data_group["rel_link_to_meas_temp"] = JLD2.Link("measurements/temperature")
+            end
+
+            jldopen(test_file, "r") do f
+                @test f["data/abs_link_to_temp"] == [20.5, 21.0, 19.8, 22.1]
+                @test f["data/rel_link_to_meas_temp"] == [20.5, 21.0, 19.8, 22.1]
+            end
+        end
+    end
+
+    @testset "Soft Link Error Handling" begin
+        # Test error conditions for broken soft links
+        mktempdir() do dir
+            test_file = joinpath(dir, "soft_link_errors_test.jld2")
+
+            jldopen(test_file, "w") do f
+                data_group = JLD2.Group(f, "data")
+                f["data/existing"] = 42
+
+                # Create soft links to non-existent targets
+                data_group["broken_absolute"] = JLD2.Link("/nonexistent/path")
+                data_group["broken_relative"] = JLD2.Link("../missing/data")
+                f.root_group["broken_root"] = JLD2.Link("/does/not/exist")
+            end
+
+            jldopen(test_file, "r") do f
+                # Test that broken soft links throw appropriate errors
+                @test_throws ArgumentError f["data/broken_absolute"]
+                @test_throws ArgumentError f["data/broken_relative"]
+                @test_throws ArgumentError f["broken_root"]
+            end
+        end
+    end
+end

--- a/test/links.jl
+++ b/test/links.jl
@@ -114,6 +114,19 @@ end
         f["soft_link_to_data"] = JLD2.Link("/original_data")
     end
 
+    jldopen("test_main.jld2", "r+") do f
+        @test f["direct_external"] == collect(1:5)
+        @test_throws ArgumentError f["direct_external/dummy"] = 42
+        @test_throws ArgumentError f["original_data/dummy"] = 42
+
+        jldopen("test_external.jld2" "r") do _
+            # Hit different code path if external file is already open
+            @test f["direct_external"] == collect(1:5)
+        end
+    end
+
+
+
     # Clean up test files
     for file in ["test_main.jld2", "test_external.jld2"]
         isfile(file) && rm(file)

--- a/test/links.jl
+++ b/test/links.jl
@@ -119,7 +119,7 @@ end
         @test_throws ArgumentError f["direct_external/dummy"] = 42
         @test_throws ArgumentError f["original_data/dummy"] = 42
 
-        jldopen("test_external.jld2" "r") do _
+        jldopen("test_external.jld2", "r") do _
             # Hit different code path if external file is already open
             @test f["direct_external"] == collect(1:5)
         end
@@ -175,9 +175,9 @@ using JLD2: UnsupportedFeatureException
 
             jldopen(test_file, "r") do f
                 # Test that broken soft links throw appropriate errors
-                @test_throws ArgumentError f["data/broken_absolute"]
-                @test_throws ArgumentError f["data/broken_relative"]
-                @test_throws ArgumentError f["broken_root"]
+                @test_throws KeyError f["data/broken_absolute"]
+                @test_throws KeyError f["data/broken_relative"]
+                @test_throws KeyError f["broken_root"]
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,8 @@ include("unpack_test.jl")
 include("dataset_api.jl")
 include("test_dataset_show.jl")
 include("mmap_test.jl")
-include("generic_io_tests.jl")  # Unified tests for all IO types
+include("generic_io_tests.jl")
+include("links.jl")
 
 using TestItemRunner
 


### PR DESCRIPTION
Add Soft Links and External Links Support

  This PR implements soft links and external links in JLD2, bringing enhanced HDF5 compatibility and enabling cross-file
  dataset references.

  Changes

  Core Link System
  - Introduced unified Link type supporting three link modes: hard links (direct offsets), soft links (path-based references
  within the same file), and external links (references to datasets in other files)
  - Added type predicates is_hard_link(), is_soft_link(), and is_external_link() for zero-cost link type checking
  - Implemented getoffset() function to transparently resolve links, with recursive soft link resolution

  API
  - New user-facing constructor: JLD2.Link(path; file=nothing) for creating soft and external links
  - `Link` is not exported because it is a very generic name and not many people will be using this.
  - Links are resolved on access, making them work seamlessly with existing getindex operations

  Internal Changes
  - Updated Group to store Link objects instead of raw RelOffset values in both unwritten_links and written_links
  - Modified link message parsing to handle HDF5 link types (0=hard, 1=soft, 64=external)
  - Enhanced pathize() and haskey() to properly handle all link types during path traversal
  - Updated group display to show appropriate icons for different link types

  Documentation
  - Added docs/src/external_links.md with usage examples and link type descriptions

  Usage Example
```
  jldopen("file.jld2", "w") do f
      f["data"] = [1, 2, 3, 4, 5]
      f["alias"] = JLD2.Link("/data")                        # Soft link
      f["remote"] = JLD2.Link("/dataset"; file="other.jld2") # External link
  end
```