### PR TITLE
proper exception printing

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -128,6 +128,14 @@ UnsupportedFeatureException() = UnsupportedFeatureException("")
 InvalidDataException() = InvalidDataException("")
 InternalError() = InternalError("")
 
+Base.showerror(io::IO, ex::UnsupportedVersionException) =
+    print(io, "UnsupportedVersionException: ", ex.msg)
+Base.showerror(io::IO, ex::UnsupportedFeatureException) =
+    print(io, "UnsupportedFeatureException: ", ex.msg)
+Base.showerror(io::IO, ex::InvalidDataException) =
+    print(io, "InvalidDataException: ", ex.msg)
+Base.showerror(io::IO, ex::InternalError) =
+    print(io, "InternalError: ", ex.msg)
 
 ## Internal types
 


### PR DESCRIPTION
For once a very simple and self-contained improvement:

```
#before
julia> throw(JLD2.InvalidDataException("test\ntest\n"))
ERROR: JLD2.InvalidDataException("test\ntest\n")
Stacktrace:
 [1] top-level scope
   @ REPL[33]:1

# after
julia> throw(JLD2.InvalidDataException("test\ntest\n"))
ERROR: InvalidDataException: test
test

Stacktrace:
 [1] top-level scope
   @ REPL[37]:1
```