### PR TITLE
Backport removed precompile workload of FileIO interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.55
+ - Backport: Remove FileIO precompile workload
+
 ## 0.4.54
 
  - **Deprecation**: Do not rely on JLD2 to load a compression library. This feature will be removed in a future release. Instead explicitly add `using` statements into your scripts.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.54"
+version = "0.4.55"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -23,9 +23,6 @@
                 end
             end
 
-            load(path)
-            load(path; nested=true)
-
             nothing
         end
     end


### PR DESCRIPTION
This PR should allow JLD2 v0.4  to successfully compile on latest julia. 
This is necessary because many packages are still stuck on the v0.4 JLD2 versions due to transient dependencies and their compat bounds.