### PR TITLE
fix edge case in type loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.4
+ - Fix edge case in datatype loading (#692)
+
 ## 0.6.3
  - Add keyword argument constructors to Filters
  - Allow negative compression levels for the ZstdFilter

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD2"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ChunkCodecLibZlib = "4c0bbee4-addc-4d73-81a0-b6caacae83c8"

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -210,7 +210,7 @@ function jlread(io::IO, ::Type{CompoundDatatype})
         names[i] = Symbol(read_bytestring(io))
         # Byte offset of member
         if version == 2 || version == 1
-            skip(io, 8-mod1(sizeof(names[i]),8)-1)
+            skip(io, 8-mod1(sizeof(names[i])+1,8))
             offsets[i] = jlread(io, UInt32)
         elseif dt.size <= typemax(UInt8)
             offsets[i] = jlread(io, UInt8)


### PR DESCRIPTION
This MR fixes #692 .

The original code `8-mod1(sizeof(names[i]),8)-1` the correct result most of the time but not always.
The corrected version is ` 8-mod1(sizeof(names[i])+1,8)`.
