### PR TITLE
Use memchr for safe and performant read_bytestring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
  - Support for directly reading from and writing to Vector{UInt8}
  - Fix for working with opened IOStream objects
+ - Proper boundscheck for internal `read_bytestring`
 
 ## 0.6.3
  - Fix edge case in datatype loading (#692)


### PR DESCRIPTION
This matches what `findfirst` does:
https://github.com/JuliaLang/julia/blob/cab2c74737f14e72df63f078921e11ceca0cdc8a/base/strings/search.jl#L191

